### PR TITLE
refactor the code to allow overwriting the function to get config

### DIFF
--- a/examples/use_cutom_config_func.py
+++ b/examples/use_cutom_config_func.py
@@ -1,0 +1,20 @@
+import torch
+import flag_attn
+
+
+# replace the default config function
+from flag_attn import flash
+def get_fwd_config(B, H, M, N, D, causal):
+    return (64, 64, 1, 4)
+flash.get_fwd_config = get_fwd_config
+
+B, H, M, N, D = 2, 16, 4096, 4096, 128
+causal = True
+
+q = torch.randn(B, H, M, D, dtype=torch.bfloat16, device="cuda:0", requires_grad=True)
+k = torch.randn(B, H, N, D, dtype=torch.bfloat16, device="cuda:0", requires_grad=True)
+v = torch.randn(B, H, N, D, dtype=torch.bfloat16, device="cuda:0", requires_grad=True)
+
+o = flag_attn.flash_attention(q, k, v, causal=causal)
+go = torch.randn_like(o)
+gq, gk, gv = torch.autograd.grad(o, (q, k, v), go)

--- a/tests/flag_attn/test_flash_attention.py
+++ b/tests/flag_attn/test_flash_attention.py
@@ -69,7 +69,7 @@ def test_attention_fwd(B, H, T, D, P_SEQ, causal, stride_order, dtype, scale, de
 @pytest.mark.parametrize('causal', [True, False])
 @pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize('stride_order', ['BHTD', 'BTHD'])
-def test_attention_fwd_bwd(B, H, T, D, P_SEQ, causal, stride_order, dtype, scale, device_id):
+def test_attention_bwd(B, H, T, D, P_SEQ, causal, stride_order, dtype, scale, device_id):
     device = f"cuda:{device_id}"
     if stride_order == "BHTD":
         q = torch.empty((B, H, T, D), dtype=dtype, device=device).normal_(mean=0., std=scale).requires_grad_()

--- a/tests/flag_attn/test_piecewise_attention.py
+++ b/tests/flag_attn/test_piecewise_attention.py
@@ -63,7 +63,7 @@ def test_attention_fwd(B, H, T, D, P_SEQ, causal, stride_order, dtype, scale, de
 @pytest.mark.parametrize('causal', [True, False])
 @pytest.mark.parametrize('stride_order', ['BHTD', 'BTHD'])
 @pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16])
-def test_attention_fwd_bwd(B, H, T, D, P_SEQ, causal, stride_order, dtype, scale, device_id):
+def test_attention_bwd(B, H, T, D, P_SEQ, causal, stride_order, dtype, scale, device_id):
     device = f"cuda:{device_id}"
     if stride_order == "BHTD":
         q1 = torch.empty((B, H, T, D), dtype=dtype, device=device).normal_(mean=0., std=scale).requires_grad_()


### PR DESCRIPTION
1. Refactor the code the allow overwriting the function to get config;
2. Add a fall-back config（`BLOCK_M, BLOCK_N, num_stages, num_warps = 32, 32, 1, 4`） when no rules match the device and the input;
3. Add an example for using custom config(examples/use_cutom_config_func.py);
4. rename test cases 'test_attention_fwd_bwd' to 'test_attention_bwd' to allow better filtering with pytest.