### PR TITLE
add options to retutn log normalizer & total attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,13 @@ python piecewise_benchmark.py
 The implementation of FlashAttention in the Triton language. The interface is.
 
 ```python
-flash_attention(q, k, v, causal=False, sm_scale=None)
+flash_attention(q, k, v, causal=False, sm_scale=None, return_log_normalizer=False, return_total_attention=False)
 ```
+
+In addition to the attention outputs, it can return some extra outputs dependes on `return_log_normalizer` and `return_total_attention`.
+
+1. log_normalizer: shape (batch_size, num_heads, seqlen_q). The log normalizer of the softmax inside attention operation.
+2. total_attention: shape (batch_size, num_heads, seqlen_q). The sum of attention weights along q's sequence axis.
 
 ### piecewise_attention
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ flash_attention(q, k, v, causal=False, sm_scale=None, return_log_normalizer=Fals
 In addition to the attention outputs, it can return some extra outputs dependes on `return_log_normalizer` and `return_total_attention`.
 
 1. log_normalizer: shape (batch_size, num_heads, seqlen_q). The log normalizer of the softmax inside attention operation.
-2. total_attention: shape (batch_size, num_heads, seqlen_q). The sum of attention weights along q's sequence axis.
+2. total_attention: shape (batch_size, num_heads, seqlen_k). The sum of attention weights along q's sequence axis.
 
 ### piecewise_attention
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -101,8 +101,13 @@ python piecewise_benchmark.py
 Triton 语言实现的 FlashAttention, 接口如下。
 
 ```python
-flash_attention(q, k, v, causal=False, sm_scale=None)
+flash_attention(q, k, v, causal=False, sm_scale=None, return_log_normalizer=False, return_total_attention=False)
 ```
+
+除了 attention 的输出之外，它还可以根据 `return_log_normalizer` 和 `return_total_attention=False` 返回一些额外的输出。
+
+1. log_normalizer: 形状 (batch_size, num_heads, seqlen_q), attention 运算内部的 softmax 运算的 log normalizer.
+2. total_attention: 形状 (batch_size, num_heads, seqlen_q). attention weights 沿着 q 的序列轴上求和的结果。
 
 ### piecewise_attention
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -107,7 +107,7 @@ flash_attention(q, k, v, causal=False, sm_scale=None, return_log_normalizer=Fals
 除了 attention 的输出之外，它还可以根据 `return_log_normalizer` 和 `return_total_attention=False` 返回一些额外的输出。
 
 1. log_normalizer: 形状 (batch_size, num_heads, seqlen_q), attention 运算内部的 softmax 运算的 log normalizer.
-2. total_attention: 形状 (batch_size, num_heads, seqlen_q). attention weights 沿着 q 的序列轴上求和的结果。
+2. total_attention: 形状 (batch_size, num_heads, seqlen_k). attention weights 沿着 q 的序列轴上求和的结果。
 
 ### piecewise_attention
 

--- a/src/flag_attn/testing/flash.py
+++ b/src/flag_attn/testing/flash.py
@@ -3,9 +3,15 @@ import torch
 
 import math
 import torch
-import pytest
 
-def attention(q, k, v, causal, sm_scale=None, upcast=False):
+def attention(q,
+              k,
+              v,
+              causal,
+              sm_scale=None,
+              return_log_normalizer=False,
+              return_total_attention=False,
+              upcast=False):
     input_dtype = q.dtype
     if upcast:
         q, k, v = q.float(), k.float(), v.float()
@@ -20,12 +26,30 @@ def attention(q, k, v, causal, sm_scale=None, upcast=False):
 
     ms = torch.arange(q_seq_len, device=device).unsqueeze(-1)
     ns = torch.arange(kv_seq_len, device=device)
-    
+
     S = torch.matmul(q, k.transpose(2, 3)) * sm_scale
     if causal:
         S = torch.where(ms + p_seq >= ns, S, float("-inf"))
 
+    S = S.to(torch.float32)
+    if return_log_normalizer:
+        log_normalizer = torch.logsumexp(S, dim=-1)
+
     # upcast attention to fp32
     P = torch.softmax(S, dim=-1, dtype=torch.float32)
-    attn_output = torch.matmul(P.to(v.dtype), v)
-    return attn_output.to(input_dtype)
+    if causal:
+        P = torch.where(ms + p_seq >= ns, P, 0.0)
+
+    if return_total_attention:
+        tot_attn = torch.sum(P, dim=-2)
+
+    attn_output = torch.matmul(P.to(v.dtype), v).to(input_dtype)
+
+    has_extra_return = return_log_normalizer or return_total_attention
+    if has_extra_return:
+        outs = (attn_output, 
+                 log_normalizer if return_log_normalizer else None, 
+                 tot_attn if return_total_attention else None)
+        return outs
+    else:
+        return attn_output


### PR DESCRIPTION
1. Add a new kernel to compute the total amount of attention that each `k` receives from all `q`s. It returns a `(batch_size, num_heads, seqlen_k)`;
2. Add an option `return_log_normalizer` for `flash_attention`. If `return_log_normalizer` is True, it returns the log normalizer of softmax, a tensor of shape `(batch_size, num_heads, seqlen_q)`;
3. Add an option `return_total_attention` for `flash_attention`. If `return_total_attention` is True, it returns the total attention(the sum of attention weight each `k` receives from all `q`s), a tensor of shape `(batch_size, num_heads, seqlen_k)`.

While `log_normalizer` is a free lunch, which is required to compute the attention output, `total_attention` comes with the cost of launching another kernel, with a different grid partitioning. 

<img width="907" alt="图片" src="https://github.com/FlagOpen/FlagAttention/assets/16222986/3bc07775-e6ee-4e49-8ee1-c9834e705043">


example usage:

```python
import torch
import flag_attn

B, H, M, N, D = 2, 4, 100, 100, 128
causal = False
q = torch.randn((B, H, M, D), dtype=torch.bfloat16, device="cuda")
k = torch.randn((B, H, N, D), dtype=torch.bfloat16, device="cuda")
v = torch.randn((B, H, N, D), dtype=torch.bfloat16, device="cuda")

o, log_normalizer, cum_attn = flag_attn.flash_attention(q, k, v, causal=causal, return_log_normalizer=True, return_total_attention=True)
```