### PR TITLE
Change the causal masking when seqlen_q > seqlen_kv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # results of benchmark
 benchmark/results*/
+playground/
 
 # version, since setuptools-scm is used, this file is automatic generated when building the package
 src/flag_attn/_version.py

--- a/examples/flash_attention_example.py
+++ b/examples/flash_attention_example.py
@@ -1,0 +1,19 @@
+import torch
+import flag_attn
+
+B, H, M, N, D = 2, 16, 4000, 4000, 128
+causal = True
+
+q = torch.randn(B, H, M, D, dtype=torch.bfloat16, device="cuda:0", requires_grad=True)
+k = torch.randn(B, H, N, D, dtype=torch.bfloat16, device="cuda:0", requires_grad=True)
+v = torch.randn(B, H, N, D, dtype=torch.bfloat16, device="cuda:0", requires_grad=True)
+
+
+o_ref = flag_attn.testing.flash_attention(q, k, v, causal=causal, upcast=True)
+o = flag_attn.flash_attention(q, k, v, causal=causal)
+o_torch = flag_attn.testing.flash_attention(q, k, v, causal=causal)
+
+go = torch.randn_like(o)
+gq_ref, gk_ref, gv_ref = torch.autograd.grad(o_ref, (q, k, v), go)
+gq, gk, gv = torch.autograd.grad(o, (q, k, v), go)
+gq_torch, gk_torch, gv_torch = torch.autograd.grad(o_torch, (q, k, v), go)

--- a/examples/flash_attention_with_aux_outputs.py
+++ b/examples/flash_attention_with_aux_outputs.py
@@ -1,0 +1,23 @@
+import torch
+import flag_attn
+
+
+B, H, M, N, D = 2, 4, 10, 20, 128
+causal = False
+q = torch.randn((B, H, M, D), dtype=torch.bfloat16, device="cuda", requires_grad=True)
+k = torch.randn((B, H, N, D), dtype=torch.bfloat16, device="cuda", requires_grad=True)
+v = torch.randn((B, H, N, D), dtype=torch.bfloat16, device="cuda", requires_grad=True)
+
+o, logz, tot_attn = flag_attn.flash_attention(
+	q, k, v, causal=causal, return_log_normalizer=True, return_total_attention=True)
+o_ref, logz_ref, tot_attn_ref = flag_attn.testing.flash_attention(
+	q, k, v, causal=causal, 
+	return_log_normalizer=True, return_total_attention=True, pcast=True)
+
+print("log normalizer")
+print(logz[0, 0]) 
+print(logz_ref[0, 0])
+
+print("total attention")
+print(tot_attn[0, 0]) 
+print(tot_attn_ref[0, 0])

--- a/src/flag_attn/flash.py
+++ b/src/flag_attn/flash.py
@@ -16,7 +16,7 @@ class FlashAttention(torch.autograd.Function):
 
         B, H, M, D = q.shape
         N = k.shape[2]
-        P_SEQ = N - M if N > M else 0
+        P_SEQ = N - M 
 
         if sm_scale is None:
             sm_scale = 1. / math.sqrt(D)
@@ -41,7 +41,7 @@ class FlashAttention(torch.autograd.Function):
                 v.stride(0), v.stride(1), v.stride(2), v.stride(3),
                 o.stride(0), o.stride(1), o.stride(2), o.stride(3),
                 B, H, M, N, P_SEQ,
-                BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_DMODEL=D, IS_CAUSAL=causal,
+                BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_DMODEL=D, IS_CAUSAL=causal, LARGER_M=M>N,
                 DIVISIBLE_M=divisible_m, DIVISIBLE_N=divisible_n, 
                 num_warps=num_warps, num_stages=num_stages,
             )
@@ -222,7 +222,7 @@ def _fwd_kernel(
     stride_oz, stride_oh, stride_om, stride_ok,
     Z, H, M, N, P_SEQ,
     BLOCK_M: tl.constexpr, BLOCK_DMODEL: tl.constexpr, BLOCK_N: tl.constexpr, 
-    IS_CAUSAL: tl.constexpr,
+    IS_CAUSAL: tl.constexpr, LARGER_M: tl.constexpr,
     DIVISIBLE_M: tl.constexpr, DIVISIBLE_N: tl.constexpr,
 ):
     input_dtype = Q.dtype.element_ty
@@ -289,6 +289,7 @@ def _fwd_kernel(
     # See also https://github.com/FlagOpen/FlagAttention/pull/8
     if IS_CAUSAL:
         hi = tl.minimum(N, P_SEQ + (start_m + 1) * BLOCK_M)
+        hi = tl.maximum(0, hi)
     else:
         hi = N
 
@@ -336,8 +337,12 @@ def _fwd_kernel(
         v_ptrs += BLOCK_N * stride_vn
 
     # write back l & o
-    acc = acc * (1.0 / l_i[:, None])
-    l = m_i * sm_scale + tl.log(l_i) # log(normalizer)
+    if IS_CAUSAL and LARGER_M:
+        acc = tl.where(offs_m[:, None] + P_SEQ < 0, 0.0, acc * (1.0 / l_i[:, None]))
+        l = m_i * sm_scale + tl.log(l_i) # log(normalizer)
+    else:
+        acc = acc * (1.0 / l_i[:, None])
+        l = m_i * sm_scale + tl.log(l_i) # log(normalizer)
     if DIVISIBLE_M:
         tl.store(l_ptrs, l, cache_modifier=".cg")
         tl.store(o_ptrs, acc.to(input_dtype), cache_modifier=".cg")

--- a/src/flag_attn/flash.py
+++ b/src/flag_attn/flash.py
@@ -16,7 +16,8 @@ class FlashAttention(torch.autograd.Function):
 
         B, H, M, D = q.shape
         N = k.shape[2]
-        P_SEQ = N - M 
+        P_SEQ = N - M
+        larger_m = M > N
 
         if sm_scale is None:
             sm_scale = 1. / math.sqrt(D)
@@ -41,7 +42,8 @@ class FlashAttention(torch.autograd.Function):
                 v.stride(0), v.stride(1), v.stride(2), v.stride(3),
                 o.stride(0), o.stride(1), o.stride(2), o.stride(3),
                 B, H, M, N, P_SEQ,
-                BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_DMODEL=D, IS_CAUSAL=causal, LARGER_M=M>N,
+                BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_DMODEL=D, 
+                IS_CAUSAL=causal, LARGER_M=larger_m,
                 DIVISIBLE_M=divisible_m, DIVISIBLE_N=divisible_n, 
                 num_warps=num_warps, num_stages=num_stages,
             )
@@ -84,7 +86,8 @@ class FlashAttention(torch.autograd.Function):
 
         B, H, M, D = q.shape
         N = k.shape[2]
-        P_SEQ = N - M if N > M else 0
+        P_SEQ = N - M
+        larger_m = M > N
 
         if sm_scale is None:
             sm_scale = 1. / math.sqrt(D)
@@ -142,7 +145,8 @@ class FlashAttention(torch.autograd.Function):
                 do.stride(0), do.stride(1), do.stride(2), do.stride(3),
                 dq.stride(0), dq.stride(1), dq.stride(2), dq.stride(3),
                 B, H, M, N, P_SEQ,
-                BLOCK_M=BLOCK_M, BLOCK_DMODEL=D, BLOCK_N=BLOCK_N, CAUSAL=causal,
+                BLOCK_M=BLOCK_M, BLOCK_DMODEL=D, BLOCK_N=BLOCK_N, 
+                CAUSAL=causal, LARGER_M=larger_m,
                 DIVISIBLE_M=divisible_m, DIVISIBLE_N=divisible_n,
                 num_stages=num_stages, num_warps = num_warps,
             )
@@ -289,7 +293,8 @@ def _fwd_kernel(
     # See also https://github.com/FlagOpen/FlagAttention/pull/8
     if IS_CAUSAL:
         hi = tl.minimum(N, P_SEQ + (start_m + 1) * BLOCK_M)
-        hi = tl.maximum(0, hi)
+        if LARGER_M:
+            hi = tl.maximum(0, hi)
     else:
         hi = N
 
@@ -338,11 +343,13 @@ def _fwd_kernel(
 
     # write back l & o
     if IS_CAUSAL and LARGER_M:
-        acc = tl.where(offs_m[:, None] + P_SEQ < 0, 0.0, acc * (1.0 / l_i[:, None]))
-        l = m_i * sm_scale + tl.log(l_i) # log(normalizer)
+        is_empty_line = (offs_m + P_SEQ) < 0
+        acc = tl.where(is_empty_line[:, None], 0.0, acc * (1.0 / l_i[:, None]))
+        l = tl.where(is_empty_line, float("-inf"), m_i * sm_scale + tl.log(l_i))
     else:
         acc = acc * (1.0 / l_i[:, None])
         l = m_i * sm_scale + tl.log(l_i) # log(normalizer)
+    
     if DIVISIBLE_M:
         tl.store(l_ptrs, l, cache_modifier=".cg")
         tl.store(o_ptrs, acc.to(input_dtype), cache_modifier=".cg")
@@ -584,7 +591,7 @@ def _bwd_q_kernel(
     stride_dqz, stride_dqh, stride_dqm, stride_dqk,
     Z, H, M, N, P_SEQ,
     BLOCK_M: tl.constexpr, BLOCK_DMODEL: tl.constexpr, BLOCK_N: tl.constexpr,
-    CAUSAL: tl.constexpr, 
+    CAUSAL: tl.constexpr, LARGER_M: tl.constexpr,
     DIVISIBLE_M: tl.constexpr, DIVISIBLE_N: tl.constexpr,
 ):
     input_dtype = Q.dtype.element_ty
@@ -647,6 +654,8 @@ def _bwd_q_kernel(
     # see note "Loop-Bound-For-N"
     if CAUSAL:
         hi = tl.minimum(N, P_SEQ + (start_m + 1) * BLOCK_M)
+        if LARGER_M:
+            hi = tl.maximum(0, hi)
     else:
         hi = N
 

--- a/src/flag_attn/testing/flash.py
+++ b/src/flag_attn/testing/flash.py
@@ -21,7 +21,7 @@ def attention(q,
         sm_scale = 1. / math.sqrt(D)
     kv_seq_len = k.shape[-2]
     q_seq_len = q.shape[-2]
-    p_seq = kv_seq_len - q_seq_len # if kv_seq_len > q_seq_len else 0
+    p_seq = kv_seq_len - q_seq_len
     device = q.device
 
     ms = torch.arange(q_seq_len, device=device).unsqueeze(-1)

--- a/src/flag_attn/testing/flash.py
+++ b/src/flag_attn/testing/flash.py
@@ -21,7 +21,7 @@ def attention(q,
         sm_scale = 1. / math.sqrt(D)
     kv_seq_len = k.shape[-2]
     q_seq_len = q.shape[-2]
-    p_seq = kv_seq_len - q_seq_len if kv_seq_len > q_seq_len else 0
+    p_seq = kv_seq_len - q_seq_len # if kv_seq_len > q_seq_len else 0
     device = q.device
 
     ms = torch.arange(q_seq_len, device=device).unsqueeze(-1)

--- a/src/flag_attn/testing/piecewise.py
+++ b/src/flag_attn/testing/piecewise.py
@@ -12,7 +12,7 @@ def attention(q1, k1, q2, k2, v, dist_threshold, causal, sm_scale=None, upcast=F
         sm_scale = 1. / math.sqrt(D)
     kv_seq_len = k1.shape[-2]
     q_seq_len = q1.shape[-2]
-    p_seq = kv_seq_len - q_seq_len if kv_seq_len > q_seq_len else 0
+    p_seq = kv_seq_len - q_seq_len
     device = q1.device
 
     ms = torch.arange(q_seq_len, device=device).unsqueeze(-1)
@@ -28,6 +28,8 @@ def attention(q1, k1, q2, k2, v, dist_threshold, causal, sm_scale=None, upcast=F
 
     # upcast attention to fp32
     P = torch.softmax(S, dim=-1, dtype=torch.float32).to(v.dtype)
+    if causal:
+        P = torch.where(ms + p_seq >= ns, P, 0.0)
     attn_output = torch.matmul(P, v)
     return attn_output.to(input_dtype)
 

--- a/src/flag_attn/total.py
+++ b/src/flag_attn/total.py
@@ -14,7 +14,7 @@ def total_attention(q, k, l, causal=False, sm_scale=None):
 
     B, H, M, D = q.shape
     N = k.shape[2]
-    P_SEQ = N - M if N > M else 0
+    P_SEQ = N - M
 
     if sm_scale is None:
         sm_scale = 1. / math.sqrt(D)

--- a/tests/flag_attn/test_flash_attention.py
+++ b/tests/flag_attn/test_flash_attention.py
@@ -67,6 +67,7 @@ def test_attention_fwd(B, H, M, N, D, causal, stride_order, dtype, scale, device
     (2, 4, 4096, 4001, 128),
     (1, 2, 8192, 8202, 16),
     (1, 2, 8192, 8192, 32),
+    (2, 4, 10006, 10, 128),
 ])
 @pytest.mark.parametrize('causal', [True, False])
 @pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16])


### PR DESCRIPTION
Change the causal masking when `seqlen_q > seqlen_kv`. 

Before
![图片](https://github.com/FlagOpen/FlagAttention/assets/16222986/25d1d34b-6971-49d1-9d0c-8baa3ae478d0)

After
![图片](https://github.com/FlagOpen/FlagAttention/assets/16222986/4cfdf6f0-739e-45ad-b0c5-6c093ed905fb)

In the case when `seqlen_q > seqlen_kv` and causal masking is applied, some `q`s cannot attend to any `k`s, so the corresponding output is zero. 

After this PR, the causal masking is the same as flash_attn 2.1+. (See also https://github.com/Dao-AILab/flash-attention#21-change-behavior-of-causal-flag)



