### PR TITLE
fix a bug in config selection introduced in PR #9

### DIFF
--- a/src/flag_attn/flash.py
+++ b/src/flag_attn/flash.py
@@ -95,7 +95,7 @@ class FlashAttention(torch.autograd.Function):
         # to work around https://github.com/openai/triton/issues/2441
         device = torch.cuda.device_of(q)
         with torch.cuda.device(device):
-            config = get_fwd_config(B, H, M, N, D, causal)
+            config = get_bwd_config(B, H, M, N, D, causal)
             BLOCK_M, BLOCK_N, num_stages, num_warps = config
 
             divisible_m = M % BLOCK_M == 0

--- a/src/flag_attn/piecewise.py
+++ b/src/flag_attn/piecewise.py
@@ -384,10 +384,10 @@ def get_bwd_config(B, H, M, N, D, causal):
             else:
                 BLOCK_M, BLOCK_N, num_stages, num_warps = 32, 64, 2, 4
         
-        BLOCK_M = 64 if D<=64 else 128
-        BLOCK_N = 64
-        num_stages = 1 if D<=64 else (2 if not causal else 1)
-        num_warps = 4 if D <=64 else 8
+        # BLOCK_M = 64 if D<=64 else 128
+        # BLOCK_N = 64
+        # num_stages = 1 if D<=64 else (2 if not causal else 1)
+        # num_warps = 4 if D <=64 else 8
     # RTX-3090, ...
     elif torch.cuda.get_device_capability() == (8, 6):
         if not causal:


### PR DESCRIPTION
1. In PR #9, the backward function of flash_attention misused the config for the forward function, which caused out-of-shared-memory error.
2. fix config selection for piecewise_attention.