### PR TITLE
add paged-attention

### DIFF
--- a/benchmark/paged_benchmark.py
+++ b/benchmark/paged_benchmark.py
@@ -1,10 +1,6 @@
 import torch
-
 import triton
-import triton.language as tl
-
 import flag_attn
-
 
 NUM_BLOCKS = 1000
 warmup = 200
@@ -14,6 +10,8 @@ try:
     from vllm._C import ops as vllm_ops
 
     HAS_VLLM = True
+
+    # required vllm 0.3.0
     import vllm
 
     print("vllm.__version__", vllm.__version__)
@@ -22,7 +20,7 @@ except BaseException:
 
 
 def vllm_paged_attention(
-    output: torch.Tensor,
+    out: torch.Tensor,
     query: torch.Tensor,
     key_cache: torch.Tensor,
     value_cache: torch.Tensor,
@@ -35,11 +33,9 @@ def vllm_paged_attention(
     PARTITION_SIZE: int = 512,
     version: int = 1,
 ):
-
     if version == 1:
-        # block_size 8, 16, 32
         vllm_ops.paged_attention_v1(
-            output,
+            out,
             query,
             key_cache,
             value_cache,
@@ -55,23 +51,23 @@ def vllm_paged_attention(
     elif version == 2:
         num_partitions = (max_context_len + PARTITION_SIZE - 1) // PARTITION_SIZE
         assert PARTITION_SIZE % block_size == 0
-        num_seqs, num_heads, head_size = output.shape
-        tmp_output = torch.empty(
+        num_seqs, num_heads, head_size = out.shape
+        tmp_out = torch.empty(
             size=(num_seqs, num_heads, num_partitions, head_size),
-            dtype=output.dtype,
-            device=output.device,
+            dtype=out.dtype,
+            device=out.device,
         )
         exp_sums = torch.empty(
             size=(num_seqs, num_heads, num_partitions),
             dtype=torch.float32,
-            device=output.device,
+            device=out.device,
         )
         max_logits = torch.empty_like(exp_sums)
         vllm_ops.paged_attention_v2(
-            output,
+            out,
             exp_sums,
             max_logits,
-            tmp_output,
+            tmp_out,
             query,
             key_cache,
             value_cache,
@@ -98,18 +94,18 @@ def vllm_paged_attention(
             line_names=["triton"] + ([f"vllm-{vllm.__version__}"] if HAS_VLLM else []),
             styles=[("red", "-"), ("blue", "-")],
             ylabel="tflop/s",
-            plot_name=f"vllm_paged_attention-B{num_seqs}-G{query_group_size}-D{head_size}-block_size{block_size}-v{version}",
+            plot_name=f"vllm_paged_attention-B{num_seqs}-G{query_group_size}-D{head_size}-bs{block_size}-v{version}",
             args={
                 "num_seqs": num_seqs,
                 "num_query_heads": 64,
                 "query_group_size": query_group_size,
                 "head_size": head_size,
                 "block_size": block_size,
-                "version": version,
+                "vllm_version": version,
                 "dtype": dtype,
             },
         )
-        for num_seqs in [1, 32]
+        for num_seqs in [1, 32, 64]
         for query_group_size in [1, 8]
         for head_size in [64, 128]
         for block_size in [16, 32]
@@ -124,7 +120,7 @@ def paged_attention_benchmark_with_vllm(
     head_size,
     block_size,
     context_len,
-    version,
+    vllm_version,
     provider,
     dtype=torch.float16,
     device="cuda",
@@ -157,7 +153,6 @@ def paged_attention_benchmark_with_vllm(
 
     if provider == "triton":
         fn = lambda: flag_attn.paged_attention(
-            out,
             q,
             k_cache,
             v_cache,
@@ -165,10 +160,9 @@ def paged_attention_benchmark_with_vllm(
             block_tables,
             attn_scale,
             context_len,
-            version=version,
         )
-        print(f"vllm_paged_attention-B{num_seqs}-G{query_group_size}-D{head_size}-block_size{block_size}-v{version}: ",fn())
         ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+
     if provider == "vllm":
         # Correctness error, does not affect performance results
         fn = lambda: vllm_paged_attention(
@@ -183,147 +177,13 @@ def paged_attention_benchmark_with_vllm(
             block_size,
             context_len,
             PARTITION_SIZE=512,
-            version=1,
+            version=vllm_version,
         )
         ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
 
-    total_flops = (
-        2.0 * num_seqs * num_query_heads * 2 * context_len * head_size
-    )
+    total_flops = 2.0 * num_seqs * num_query_heads * 2 * context_len * head_size
     return total_flops / ms * 1e-9
 
+
 if HAS_VLLM:
-    paged_attention_benchmark_with_vllm.run(
-        save_path="./vllm_result", print_data=True
-    )  # show_plots=True,
-
-
-try:
-    from flash_attn import flash_attn_with_kvcache
-
-    HAS_FLASH = True
-    import flash_attn
-
-    print("flash_attn.__version__", flash_attn.__version__)
-except BaseException:
-    HAS_FLASH = False
-
-
-# MAX_SEQ_LEN = 4096
-@triton.testing.perf_report(
-    [
-        triton.testing.Benchmark(
-            x_names=["context_len"],
-            x_vals=[2**i for i in range(9, 15)],
-            line_arg="provider",
-            line_vals=["triton"] + (["flash"] if HAS_FLASH else []),
-            line_names=["triton"] + ([f"flash-{flash_attn.__version__}"] if HAS_FLASH else []),
-            styles=[("red", "-"), ("blue", "-")],
-            ylabel="tflop/s",
-            plot_name=f"flash_paged_attention-B{num_seqs}-G{query_group_size}-D{head_size}-block_size{block_size}-v{version}",
-            args={
-                "num_seqs": num_seqs,
-                "num_query_heads": 64,
-                "query_group_size": query_group_size,
-                "head_size": head_size,
-                "block_size": block_size,
-                "version": version,
-                "dtype": dtype,
-            },
-        )
-        for num_seqs in [1, 32]
-        for query_group_size in [1, 8]
-        for head_size in [64, 128]
-        for block_size in [256]
-        for version in [1, 2]
-        for dtype in [torch.float16]
-    ]
-)
-def paged_attention_benchmark_with_flash_attn(
-    num_seqs,
-    num_query_heads,
-    query_group_size,
-    head_size,
-    block_size,
-    context_len,
-    version,
-    provider,
-    dtype=torch.float16,
-    device="cuda",
-):
-    torch.set_default_dtype(dtype)
-    torch.set_default_device(device=device)
-
-    # torch.cuda.manual_seed(seed)
-
-    num_kv_heads = num_query_heads // query_group_size
-    # QUERY_GROUP_SIZE = num_query_heads // num_kv_heads
-    
-    # 初始化每个 seq 的长度
-    context_lens = torch.randint(1, context_len, [num_seqs],dtype=torch.int32)
-    # context_lens = torch.zeros(num_seqs, dtype=torch.int32, device=device) + context_len
-    max_context_len = context_lens.max().item()
-    max_num_blocks_per_seq = (max_context_len + block_size - 1) // block_size
-
-    attn_scale = head_size ** -0.5
-    q = torch.empty(num_seqs, num_query_heads, head_size)
-    q.uniform_(-attn_scale, attn_scale)
-    out = torch.empty_like(q)
-
-    k_cache = torch.empty(NUM_BLOCKS, num_kv_heads,block_size, head_size)
-    k_cache.uniform_(-attn_scale, attn_scale)
-    v_cache = torch.empty_like(k_cache)
-    v_cache.uniform_(-attn_scale, attn_scale)
-
-    # (NUM_SEQS, MAX_NUM_BLOCKS_PER_SEQ)
-    block_tables = torch.randint(
-        0, NUM_BLOCKS, (num_seqs, max_num_blocks_per_seq),dtype=torch.int32)
-
-    total_flops = (
-        2.0 * num_seqs * num_query_heads * 2 * context_len * head_size
-    )
-
-    if provider == "triton":
-        fn = lambda: flag_attn.paged_attention(
-            out,
-            q,
-            k_cache,
-            v_cache,
-            context_lens,
-            block_tables,
-            attn_scale,
-            max_context_len,#context_len,
-            version=version,
-        )
-        print(f"flash_paged_attention-B{num_seqs}-G{query_group_size}-D{head_size}-block_size{block_size}-v{version}: ",fn())
-        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
-        return total_flops / ms * 1e-9
-    
-    if provider == "flash":
-        q_flash = q.unsqueeze(1)
-        k_cache_flash = k_cache.permute(0,2,1,3).contiguous()
-        v_cache_flash = v_cache.permute(0,2,1,3).contiguous()
-
-        fn = lambda: flash_attn_with_kvcache(
-            q_flash,
-            k_cache_flash,
-            v_cache_flash,
-            k = None,
-            v = None,
-            rotary_cos = None,
-            rotary_sin = None,
-            cache_seqlens = context_lens,
-            cache_batch_idx = None,
-            block_table = block_tables,
-            softmax_scale = attn_scale,
-            causal = False,
-        )
-        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
-        return total_flops / ms * 1e-9
-
-
-if HAS_FLASH:
-    paged_attention_benchmark_with_flash_attn.run(
-        save_path="./flash_result", print_data=True
-    )  # show_plots=True,
-
+    paged_attention_benchmark_with_vllm.run(print_data=True)

--- a/benchmark/paged_benchmark.py
+++ b/benchmark/paged_benchmark.py
@@ -1,0 +1,329 @@
+import torch
+
+import triton
+import triton.language as tl
+
+import flag_attn
+
+
+NUM_BLOCKS = 1000
+warmup = 200
+rep = 200
+
+try:
+    from vllm._C import ops as vllm_ops
+
+    HAS_VLLM = True
+    import vllm
+
+    print("vllm.__version__", vllm.__version__)
+except BaseException:
+    HAS_VLLM = False
+
+
+def vllm_paged_attention(
+    output: torch.Tensor,
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    num_kv_heads: int,
+    scale: float,
+    block_tables: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_size: int,
+    max_context_len: int,
+    PARTITION_SIZE: int = 512,
+    version: int = 1,
+):
+
+    if version == 1:
+        # block_size 8, 16, 32
+        vllm_ops.paged_attention_v1(
+            output,
+            query,
+            key_cache,
+            value_cache,
+            num_kv_heads,
+            scale,
+            block_tables,
+            context_lens,
+            block_size,
+            max_context_len,
+            None,  # alibi_slopes
+            "auto",  # kv_cache_dtype for vllm 0.3.0
+        )
+    elif version == 2:
+        num_partitions = (max_context_len + PARTITION_SIZE - 1) // PARTITION_SIZE
+        assert PARTITION_SIZE % block_size == 0
+        num_seqs, num_heads, head_size = output.shape
+        tmp_output = torch.empty(
+            size=(num_seqs, num_heads, num_partitions, head_size),
+            dtype=output.dtype,
+            device=output.device,
+        )
+        exp_sums = torch.empty(
+            size=(num_seqs, num_heads, num_partitions),
+            dtype=torch.float32,
+            device=output.device,
+        )
+        max_logits = torch.empty_like(exp_sums)
+        vllm_ops.paged_attention_v2(
+            output,
+            exp_sums,
+            max_logits,
+            tmp_output,
+            query,
+            key_cache,
+            value_cache,
+            num_kv_heads,
+            scale,
+            block_tables,
+            context_lens,
+            block_size,
+            max_context_len,
+            None,
+            "auto",  # vllm 0.3.0
+        )
+    else:
+        raise AssertionError(f"Unknown version: {version}")
+
+
+@triton.testing.perf_report(
+    [
+        triton.testing.Benchmark(
+            x_names=["context_len"],
+            x_vals=[2**i for i in range(9, 15)],
+            line_arg="provider",
+            line_vals=["triton"] + (["vllm"] if HAS_VLLM else []),
+            line_names=["triton"] + ([f"vllm-{vllm.__version__}"] if HAS_VLLM else []),
+            styles=[("red", "-"), ("blue", "-")],
+            ylabel="tflop/s",
+            plot_name=f"vllm_paged_attention-B{num_seqs}-G{query_group_size}-D{head_size}-block_size{block_size}-v{version}",
+            args={
+                "num_seqs": num_seqs,
+                "num_query_heads": 64,
+                "query_group_size": query_group_size,
+                "head_size": head_size,
+                "block_size": block_size,
+                "version": version,
+                "dtype": dtype,
+            },
+        )
+        for num_seqs in [1, 32]
+        for query_group_size in [1, 8]
+        for head_size in [64, 128]
+        for block_size in [16, 32]
+        for version in [1, 2]
+        for dtype in [torch.float16]
+    ]
+)
+def paged_attention_benchmark_with_vllm(
+    num_seqs,
+    num_query_heads,
+    query_group_size,
+    head_size,
+    block_size,
+    context_len,
+    version,
+    provider,
+    dtype=torch.float16,
+    device="cuda",
+):
+    num_kv_heads = num_query_heads // query_group_size
+
+    context_lens = torch.zeros(num_seqs, dtype=torch.int32, device=device) + context_len
+    max_num_blocks_per_seq = (context_len + block_size - 1) // block_size
+
+    attn_scale = head_size**-0.5
+    q = torch.empty(num_seqs, num_query_heads, head_size, dtype=dtype, device=device)
+    q.uniform_(-attn_scale, attn_scale)
+    out = torch.empty_like(q)
+
+    k_cache = torch.empty(
+        NUM_BLOCKS, num_kv_heads, block_size, head_size, dtype=dtype, device=device
+    )
+    k_cache.uniform_(-attn_scale, attn_scale)
+    v_cache = torch.empty_like(k_cache)
+    v_cache.uniform_(-attn_scale, attn_scale)
+
+    # (NUM_SEQS, MAX_NUM_BLOCKS_PER_SEQ)
+    block_tables = torch.randint(
+        0,
+        NUM_BLOCKS,
+        (num_seqs, max_num_blocks_per_seq),
+        dtype=torch.int32,
+        device=device,
+    )
+
+    if provider == "triton":
+        fn = lambda: flag_attn.paged_attention(
+            out,
+            q,
+            k_cache,
+            v_cache,
+            context_lens,
+            block_tables,
+            attn_scale,
+            context_len,
+            version=version,
+        )
+        print(f"vllm_paged_attention-B{num_seqs}-G{query_group_size}-D{head_size}-block_size{block_size}-v{version}: ",fn())
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+    if provider == "vllm":
+        # Correctness error, does not affect performance results
+        fn = lambda: vllm_paged_attention(
+            out,
+            q,
+            k_cache,
+            v_cache,
+            num_kv_heads,
+            attn_scale,
+            block_tables,
+            context_lens,
+            block_size,
+            context_len,
+            PARTITION_SIZE=512,
+            version=1,
+        )
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+
+    total_flops = (
+        2.0 * num_seqs * num_query_heads * 2 * context_len * head_size
+    )
+    return total_flops / ms * 1e-9
+
+if HAS_VLLM:
+    paged_attention_benchmark_with_vllm.run(
+        save_path="./vllm_result", print_data=True
+    )  # show_plots=True,
+
+
+try:
+    from flash_attn import flash_attn_with_kvcache
+
+    HAS_FLASH = True
+    import flash_attn
+
+    print("flash_attn.__version__", flash_attn.__version__)
+except BaseException:
+    HAS_FLASH = False
+
+
+# MAX_SEQ_LEN = 4096
+@triton.testing.perf_report(
+    [
+        triton.testing.Benchmark(
+            x_names=["context_len"],
+            x_vals=[2**i for i in range(9, 15)],
+            line_arg="provider",
+            line_vals=["triton"] + (["flash"] if HAS_FLASH else []),
+            line_names=["triton"] + ([f"flash-{flash_attn.__version__}"] if HAS_FLASH else []),
+            styles=[("red", "-"), ("blue", "-")],
+            ylabel="tflop/s",
+            plot_name=f"flash_paged_attention-B{num_seqs}-G{query_group_size}-D{head_size}-block_size{block_size}-v{version}",
+            args={
+                "num_seqs": num_seqs,
+                "num_query_heads": 64,
+                "query_group_size": query_group_size,
+                "head_size": head_size,
+                "block_size": block_size,
+                "version": version,
+                "dtype": dtype,
+            },
+        )
+        for num_seqs in [1, 32]
+        for query_group_size in [1, 8]
+        for head_size in [64, 128]
+        for block_size in [256]
+        for version in [1, 2]
+        for dtype in [torch.float16]
+    ]
+)
+def paged_attention_benchmark_with_flash_attn(
+    num_seqs,
+    num_query_heads,
+    query_group_size,
+    head_size,
+    block_size,
+    context_len,
+    version,
+    provider,
+    dtype=torch.float16,
+    device="cuda",
+):
+    torch.set_default_dtype(dtype)
+    torch.set_default_device(device=device)
+
+    # torch.cuda.manual_seed(seed)
+
+    num_kv_heads = num_query_heads // query_group_size
+    # QUERY_GROUP_SIZE = num_query_heads // num_kv_heads
+    
+    # 初始化每个 seq 的长度
+    context_lens = torch.randint(1, context_len, [num_seqs],dtype=torch.int32)
+    # context_lens = torch.zeros(num_seqs, dtype=torch.int32, device=device) + context_len
+    max_context_len = context_lens.max().item()
+    max_num_blocks_per_seq = (max_context_len + block_size - 1) // block_size
+
+    attn_scale = head_size ** -0.5
+    q = torch.empty(num_seqs, num_query_heads, head_size)
+    q.uniform_(-attn_scale, attn_scale)
+    out = torch.empty_like(q)
+
+    k_cache = torch.empty(NUM_BLOCKS, num_kv_heads,block_size, head_size)
+    k_cache.uniform_(-attn_scale, attn_scale)
+    v_cache = torch.empty_like(k_cache)
+    v_cache.uniform_(-attn_scale, attn_scale)
+
+    # (NUM_SEQS, MAX_NUM_BLOCKS_PER_SEQ)
+    block_tables = torch.randint(
+        0, NUM_BLOCKS, (num_seqs, max_num_blocks_per_seq),dtype=torch.int32)
+
+    total_flops = (
+        2.0 * num_seqs * num_query_heads * 2 * context_len * head_size
+    )
+
+    if provider == "triton":
+        fn = lambda: flag_attn.paged_attention(
+            out,
+            q,
+            k_cache,
+            v_cache,
+            context_lens,
+            block_tables,
+            attn_scale,
+            max_context_len,#context_len,
+            version=version,
+        )
+        print(f"flash_paged_attention-B{num_seqs}-G{query_group_size}-D{head_size}-block_size{block_size}-v{version}: ",fn())
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+        return total_flops / ms * 1e-9
+    
+    if provider == "flash":
+        q_flash = q.unsqueeze(1)
+        k_cache_flash = k_cache.permute(0,2,1,3).contiguous()
+        v_cache_flash = v_cache.permute(0,2,1,3).contiguous()
+
+        fn = lambda: flash_attn_with_kvcache(
+            q_flash,
+            k_cache_flash,
+            v_cache_flash,
+            k = None,
+            v = None,
+            rotary_cos = None,
+            rotary_sin = None,
+            cache_seqlens = context_lens,
+            cache_batch_idx = None,
+            block_table = block_tables,
+            softmax_scale = attn_scale,
+            causal = False,
+        )
+        ms = triton.testing.do_bench(fn, warmup=warmup, rep=rep)
+        return total_flops / ms * 1e-9
+
+
+if HAS_FLASH:
+    paged_attention_benchmark_with_flash_attn.run(
+        save_path="./flash_result", print_data=True
+    )  # show_plots=True,
+

--- a/examples/paged_example.py
+++ b/examples/paged_example.py
@@ -6,6 +6,7 @@ import flag_attn
 MAX_SEQ_LEN = 4096
 NUM_BLOCKS = 2000
 
+
 def test_paged_attention(
     num_seqs: int,
     num_heads: Tuple[int, int],
@@ -14,7 +15,6 @@ def test_paged_attention(
     dtype: torch.dtype,
     seed: int,
     device: int,
-    version: int,
 ):
     torch.set_default_dtype(dtype)
     torch.set_default_device(device=device)
@@ -22,30 +22,24 @@ def test_paged_attention(
     torch.cuda.manual_seed(seed)
 
     num_query_heads, num_kv_heads = num_heads
-    QUERY_GROUP_SIZE = num_query_heads // num_kv_heads
-    
-    # 初始化每个 seq 的长度
-    context_lens = torch.randint(1, MAX_SEQ_LEN, [num_seqs],dtype=torch.int32)
+
+    context_lens = torch.randint(1, MAX_SEQ_LEN, [num_seqs], dtype=torch.int32)
     max_context_len = context_lens.max().item()
     max_num_blocks_per_seq = (max_context_len + block_size - 1) // block_size
 
-    attn_scale = head_size ** -0.5
+    attn_scale = head_size**-0.5
     q = torch.empty(num_seqs, num_query_heads, head_size)
     q.uniform_(-attn_scale, attn_scale)
-    out = torch.empty_like(q)
 
-    k_cache = torch.empty(NUM_BLOCKS, num_kv_heads,block_size, head_size)
+    k_cache = torch.empty(NUM_BLOCKS, num_kv_heads, block_size, head_size)
     k_cache.uniform_(-attn_scale, attn_scale)
     v_cache = torch.empty_like(k_cache)
     v_cache.uniform_(-attn_scale, attn_scale)
 
     # (NUM_SEQS, MAX_NUM_BLOCKS_PER_SEQ)
-    block_tables = torch.randint(
-        0, NUM_BLOCKS, (num_seqs, max_num_blocks_per_seq))
-    
-    print("version: ",version)
-    flag_attn.paged_attention(
-        out,
+    block_tables = torch.randint(0, NUM_BLOCKS, (num_seqs, max_num_blocks_per_seq))
+
+    out = flag_attn.paged_attention(
         q,
         k_cache,
         v_cache,
@@ -53,12 +47,9 @@ def test_paged_attention(
         block_tables,
         attn_scale,
         max_context_len,
-        version = version,
     )
 
-    ref_out = torch.empty_like(out)
-    flag_attn.testing.paged_attention(
-        ref_out,
+    ref_out = flag_attn.testing.paged_attention(
         q,
         k_cache,
         v_cache,
@@ -75,12 +66,12 @@ def main():
         num_seqs=32,
         num_heads=(64, 64),
         head_size=64,
-        block_size=256,
+        block_size=16,
         dtype=torch.float16,
         seed=1,
         device="cuda:0",
-        version=2,
     )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/examples/paged_example.py
+++ b/examples/paged_example.py
@@ -1,0 +1,86 @@
+import torch
+from typing import Tuple
+
+import flag_attn
+
+MAX_SEQ_LEN = 4096
+NUM_BLOCKS = 2000
+
+def test_paged_attention(
+    num_seqs: int,
+    num_heads: Tuple[int, int],
+    head_size: int,
+    block_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: int,
+    version: int,
+):
+    torch.set_default_dtype(dtype)
+    torch.set_default_device(device=device)
+
+    torch.cuda.manual_seed(seed)
+
+    num_query_heads, num_kv_heads = num_heads
+    QUERY_GROUP_SIZE = num_query_heads // num_kv_heads
+    
+    # 初始化每个 seq 的长度
+    context_lens = torch.randint(1, MAX_SEQ_LEN, [num_seqs],dtype=torch.int32)
+    max_context_len = context_lens.max().item()
+    max_num_blocks_per_seq = (max_context_len + block_size - 1) // block_size
+
+    attn_scale = head_size ** -0.5
+    q = torch.empty(num_seqs, num_query_heads, head_size)
+    q.uniform_(-attn_scale, attn_scale)
+    out = torch.empty_like(q)
+
+    k_cache = torch.empty(NUM_BLOCKS, num_kv_heads,block_size, head_size)
+    k_cache.uniform_(-attn_scale, attn_scale)
+    v_cache = torch.empty_like(k_cache)
+    v_cache.uniform_(-attn_scale, attn_scale)
+
+    # (NUM_SEQS, MAX_NUM_BLOCKS_PER_SEQ)
+    block_tables = torch.randint(
+        0, NUM_BLOCKS, (num_seqs, max_num_blocks_per_seq))
+    
+    print("version: ",version)
+    flag_attn.paged_attention(
+        out,
+        q,
+        k_cache,
+        v_cache,
+        context_lens,
+        block_tables,
+        attn_scale,
+        max_context_len,
+        version = version,
+    )
+
+    ref_out = torch.empty_like(out)
+    flag_attn.testing.paged_attention(
+        ref_out,
+        q,
+        k_cache,
+        v_cache,
+        block_tables,
+        context_lens,
+        attn_scale,
+    )
+    print(torch.abs(out - ref_out).max())
+    assert torch.allclose(out, ref_out, atol=1e-3, rtol=1e-5)
+
+
+def main():
+    test_paged_attention(
+        num_seqs=32,
+        num_heads=(64, 64),
+        head_size=64,
+        block_size=256,
+        dtype=torch.float16,
+        seed=1,
+        device="cuda:0",
+        version=2,
+    )
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,7 @@ classifiers = [
 # Not specifing triton version here because torch has its own required triton version
 # FlagAttention needs a recent version of triton (triton nightly or 2.2.0) to run.
 dependencies = [
-    "torch>=2.0.0",
-    "triton"
+    "triton>=2.2.0"
 ]
 
 [project.optional-dependencies]

--- a/src/flag_attn/__init__.py
+++ b/src/flag_attn/__init__.py
@@ -9,5 +9,6 @@ except ImportError:
 from flag_attn.piecewise import attention as piecewise_attention # noqa: F401
 from flag_attn.flash import attention as flash_attention # noqa: F401
 from flag_attn.split_kv import attention as flash_attention_split_kv # noqa: F401
+from flag_attn.paged import paged_attention as paged_attention # noqa: F401
 
 from flag_attn import testing # noqa: F401

--- a/src/flag_attn/__init__.py
+++ b/src/flag_attn/__init__.py
@@ -9,6 +9,6 @@ except ImportError:
 from flag_attn.piecewise import attention as piecewise_attention # noqa: F401
 from flag_attn.flash import attention as flash_attention # noqa: F401
 from flag_attn.split_kv import attention as flash_attention_split_kv # noqa: F401
-from flag_attn.paged import paged_attention as paged_attention # noqa: F401
+from flag_attn.paged import attention as paged_attention # noqa: F401
 
 from flag_attn import testing # noqa: F401

--- a/src/flag_attn/paged.py
+++ b/src/flag_attn/paged.py
@@ -34,6 +34,7 @@ def attention(
     # assert query_group_size > 0 and query_group_size & (query_group_size-1) == 0, f"query_group_size={query_group_size}"
 
     # config for A100
+    # TODO: support more devices and optimize
     device = torch.cuda.device_of(query)
     num_sms = torch.cuda.get_device_properties(device).multi_processor_count
     if num_splits == 0:

--- a/src/flag_attn/paged.py
+++ b/src/flag_attn/paged.py
@@ -1,0 +1,512 @@
+import torch
+import triton
+import triton.language as tl
+from typing import Optional
+
+
+def paged_attention(
+    out: torch.Tensor,  # [num_seqs, NUM_KV_HEADS * QUERY_GROUP_SIZE, HEAD_SIZE]
+    query: torch.Tensor,  # [num_seqs, NUM_KV_HEADS * QUERY_GROUP_SIZE, HEAD_SIZE]
+    key_cache: torch.Tensor,  # [num_blocks, NUM_KV_HEADS, KV_BLOCK_SIZE, HEAD_SIZE]
+    value_cache: torch.Tensor,  # [num_blocks, NUM_KV_HEADS, KV_BLOCK_SIZE, HEAD_SIZE]
+    context_lens: torch.Tensor,  # [num_seqs]
+    block_tables: torch.Tensor,  # [num_seqs, max_num_blocks_per_seq]
+    attn_scale: float,
+    max_context_len: int,
+    partition_size: int = 512,
+    version: int = 1,
+) -> None:
+    num_seqs = query.shape[0]
+    num_kv_heads = key_cache.shape[1]
+    kv_block_size = key_cache.shape[2]
+    head_size = key_cache.shape[3]
+    query_group_size = query.shape[1] // num_kv_heads
+    max_num_blocks_per_seq = block_tables.shape[1]
+    query_stride = query.stride(0)
+    kv_block_stride = key_cache.stride(0)
+    kv_head_stride = key_cache.stride(1)
+
+    if query_group_size == 1:
+        padded_group_size = 1
+    elif query_group_size < 16:
+        padded_group_size = 16
+    else:
+        padded_group_size = triton.next_power_of_2(query_group_size)
+    # FIXME: Remove these constraints.
+    assert head_size in [64, 128, 256], f"head_size={head_size}"
+    assert kv_block_size >= 16
+    assert query_group_size in [1, 2, 4, 8, 16, 32, 64, 128, 256]
+
+    # use_v1 = False
+    # dev_prop = torch.cuda.get_device_properties(0)
+    # num_sms = dev_prop.multi_processor_count
+    # if num_seqs * num_kv_heads > num_sms: # or partition_size != 0:
+    #   use_v1 = True
+    use_v1 = version == 1
+
+    if use_v1:
+        grid = (num_seqs, num_kv_heads, 1)
+        _paged_attn_v1_kernel[grid](
+            out,
+            query,
+            key_cache,
+            value_cache,
+            context_lens,
+            block_tables,
+            max_num_blocks_per_seq,
+            attn_scale,
+            query_stride,
+            kv_block_stride,
+            kv_head_stride,
+            head_size,
+            query_group_size,
+            padded_group_size,
+            num_kv_heads,
+            kv_block_size,
+        )
+        # print_config_v1()
+        return _paged_attn_v1_kernel.best_config
+
+    else:
+        # max_num_partitions = triton.cdiv(max_context_len, v2_partition_size)
+        max_num_partitions = triton.cdiv(max_context_len, 64)
+        grid = lambda META: (
+            num_seqs,
+            num_kv_heads,
+            triton.cdiv(max_context_len, META["PARTITION_SIZE"]),
+        )
+        # grid = (num_seqs, num_kv_heads, max_num_partitions)
+        m_i = torch.empty(
+            size=(num_seqs, num_kv_heads, max_num_partitions, query_group_size),
+            dtype=torch.float32,
+            device=out.device,
+        )
+        l_i = torch.empty_like(m_i)
+        tmp_out = torch.empty(
+            size=(
+                num_seqs,
+                num_kv_heads,
+                max_num_partitions,
+                query_group_size,
+                head_size,
+            ),
+            dtype=out.dtype,
+            device=out.device,
+        )
+        _paged_attn_v2_kernel[grid](
+            m_i,
+            l_i,
+            tmp_out,
+            query,
+            key_cache,
+            value_cache,
+            context_lens,
+            block_tables,
+            max_num_blocks_per_seq,
+            attn_scale,
+            query_stride,
+            kv_block_stride,
+            kv_head_stride,
+            head_size,
+            query_group_size,
+            padded_group_size,
+            num_kv_heads,
+            kv_block_size,
+            # v2_partition_size,
+        )
+        # print_config_v2()
+
+        v2_partition_size = _paged_attn_v2_kernel.best_config.kwargs["PARTITION_SIZE"]
+        # WARNING
+        assert(v2_partition_size >= kv_block_size)
+        max_num_partitions = triton.cdiv(max_context_len, v2_partition_size)
+        reduce_grid = (num_seqs, num_kv_heads)
+        _paged_attn_v2_reduce_kernel[reduce_grid](
+            out,
+            m_i,
+            l_i,
+            tmp_out,
+            context_lens,
+            max_num_partitions,
+            head_size,
+            query_group_size,
+            num_kv_heads,
+            v2_partition_size,
+            triton.next_power_of_2(max_num_partitions),
+        )
+        return _paged_attn_v2_kernel.best_config
+
+
+def run_once(func):
+    def wrapper():
+        if not wrapper.has_run:
+            func()
+            wrapper.has_run = True
+
+    wrapper.has_run = False
+    return wrapper
+
+
+@run_once
+def print_config_v1():
+    print("triton v1: ", _paged_attn_v1_kernel.best_config)
+
+
+@run_once
+def print_config_v2():
+    print("triton v2: ", _paged_attn_v2_kernel.best_config)
+
+
+def get_v1_configs():
+    configs = []
+    for num_stages in [1, 2, 3, 4]:
+        for num_warps in [1, 2, 4, 8]:
+            configs.append(
+                triton.Config({}, num_stages=num_stages, num_warps=num_warps)
+            )
+    return configs
+
+
+@triton.autotune(
+    configs=get_v1_configs(),
+    key=["KV_BLOCK_SIZE", "HEAD_SIZE", "PADDED_QUERY_GROUP_SIZE"],
+)
+@triton.jit
+def _paged_attn_v1_kernel(
+    out_ptr,
+    q_ptr,  # [num_seqs, NUM_KV_HEADS * QUERY_GROUP_SIZE, HEAD_SIZE]
+    k_cache_ptr,  # [num_blocks, NUM_KV_HEADS, KV_BLOCK_SIZE, HEAD_SIZE]
+    v_cache_ptr,
+    context_lens_ptr,
+    block_tables_ptr,
+    max_num_blocks_per_seq,
+    attn_scale,
+    Q_STRIDE: tl.constexpr,
+    KV_BLOCK_STRIDE: tl.constexpr,
+    KV_HEAD_STRIDE: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    QUERY_GROUP_SIZE: tl.constexpr,
+    PADDED_QUERY_GROUP_SIZE: tl.constexpr,
+    NUM_KV_HEADS: tl.constexpr,
+    KV_BLOCK_SIZE: tl.constexpr,
+):
+    _paged_attn_kernel(
+        out_ptr,
+        out_ptr,
+        out_ptr,
+        q_ptr,
+        k_cache_ptr,
+        v_cache_ptr,
+        context_lens_ptr,
+        block_tables_ptr,
+        max_num_blocks_per_seq,
+        attn_scale,
+        Q_STRIDE,
+        KV_BLOCK_STRIDE,
+        KV_HEAD_STRIDE,
+        HEAD_SIZE,
+        QUERY_GROUP_SIZE,
+        PADDED_QUERY_GROUP_SIZE,
+        NUM_KV_HEADS,
+        KV_BLOCK_SIZE,
+        PARTITION_SIZE=0,
+    )
+
+# todo dynamic config base on KV_BLOCK_SIZE
+def get_v2_configs():
+    configs = []
+    for partition_size in [256, 512, 1024]:
+        for num_stages in [1, 2, 3, 4]:
+            for num_warps in [1, 2, 4, 8]:
+                configs.append(
+                    triton.Config(
+                        {"PARTITION_SIZE": partition_size},
+                        num_stages=num_stages,
+                        num_warps=num_warps,
+                    )
+                )
+    return configs
+
+def get_v2_one_configs():
+    configs = []
+    configs.append(triton.Config({"PARTITION_SIZE": 128}, num_stages=3, num_warps=8))
+    return configs
+
+@triton.autotune(
+    configs=get_v2_configs(),
+    key=["KV_BLOCK_SIZE", "HEAD_SIZE", "PADDED_QUERY_GROUP_SIZE"],
+)
+@triton.jit
+def _paged_attn_v2_kernel(
+    m_i_ptr,
+    l_i_ptr,
+    out_ptr,
+    q_ptr,  # [num_seqs, NUM_KV_HEADS * QUERY_GROUP_SIZE, HEAD_SIZE]
+    k_cache_ptr,  # [num_blocks, NUM_KV_HEADS, KV_BLOCK_SIZE, HEAD_SIZE]
+    v_cache_ptr,
+    context_lens_ptr,
+    block_tables_ptr,
+    max_num_blocks_per_seq,
+    attn_scale,
+    Q_STRIDE: tl.constexpr,
+    KV_BLOCK_STRIDE: tl.constexpr,
+    KV_HEAD_STRIDE: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    QUERY_GROUP_SIZE: tl.constexpr,
+    PADDED_QUERY_GROUP_SIZE: tl.constexpr,
+    NUM_KV_HEADS: tl.constexpr,
+    KV_BLOCK_SIZE: tl.constexpr,
+    PARTITION_SIZE: tl.constexpr,
+):
+    _paged_attn_kernel(
+        m_i_ptr,
+        l_i_ptr,
+        out_ptr,
+        q_ptr,
+        k_cache_ptr,
+        v_cache_ptr,
+        context_lens_ptr,
+        block_tables_ptr,
+        max_num_blocks_per_seq,
+        attn_scale,
+        Q_STRIDE,
+        KV_BLOCK_STRIDE,
+        KV_HEAD_STRIDE,
+        HEAD_SIZE,
+        QUERY_GROUP_SIZE,
+        PADDED_QUERY_GROUP_SIZE,
+        NUM_KV_HEADS,
+        KV_BLOCK_SIZE,
+        PARTITION_SIZE,
+    )
+
+
+@triton.jit
+def _paged_attn_kernel(
+    m_i_ptr,  # [num_seqs, NUM_KV_HEADS, max_num_partitions, QUERY_GROUP_SIZE]
+    l_i_ptr,  # [num_seqs, NUM_KV_HEADS, max_num_partitions, QUERY_GROUP_SIZE]
+    out_ptr,  # [num_seqs, NUM_KV_HEADS, max_num_partitions, QUERY_GROUP_SIZE, HEAD_SIZE]
+    q_ptr,  # [num_seqs, NUM_KV_HEADS * QUERY_GROUP_SIZE, HEAD_SIZE]
+    k_cache_ptr,  # [num_blocks, NUM_KV_HEADS, KV_BLOCK_SIZE, HEAD_SIZE]
+    v_cache_ptr,  # [num_blocks, NUM_KV_HEADS, KV_BLOCK_SIZE, HEAD_SIZE]
+    context_lens_ptr,  # [num_seqs]
+    block_tables_ptr,  # [num_seqs, max_num_blocks_per_seq]
+    max_num_blocks_per_seq,
+    attn_scale,
+    Q_STRIDE: tl.constexpr,
+    KV_BLOCK_STRIDE: tl.constexpr,
+    KV_HEAD_STRIDE: tl.constexpr,
+    HEAD_SIZE: tl.constexpr,
+    QUERY_GROUP_SIZE: tl.constexpr,
+    PADDED_QUERY_GROUP_SIZE: tl.constexpr,
+    NUM_KV_HEADS: tl.constexpr,
+    KV_BLOCK_SIZE: tl.constexpr,
+    PARTITION_SIZE: tl.constexpr,
+):
+    seq_idx = tl.program_id(0)
+    kv_head_idx = tl.program_id(1)
+    partition_idx = tl.program_id(2)
+    max_num_partitions = tl.num_programs(2)
+
+    USE_PARTITIONING = PARTITION_SIZE > 0
+    context_len = tl.load(context_lens_ptr + seq_idx)
+    if USE_PARTITIONING:
+        context_start_idx = partition_idx * PARTITION_SIZE
+        if context_start_idx >= context_len:
+            # Early exit.
+            return
+        context_end_idx = tl.minimum(context_start_idx + PARTITION_SIZE, context_len)
+        num_blocks = tl.cdiv(context_end_idx - context_start_idx, KV_BLOCK_SIZE)
+    else:
+        context_start_idx = 0
+        num_blocks = tl.cdiv(context_len, KV_BLOCK_SIZE)
+
+    block_offset = tl.arange(0, KV_BLOCK_SIZE)
+    head_offset = tl.arange(0, HEAD_SIZE)
+    kv_offset = kv_head_idx * KV_HEAD_STRIDE
+    kv_offset += block_offset[:, None] * HEAD_SIZE + head_offset[None, :]
+
+    # Load queries.
+    query_offset = seq_idx * Q_STRIDE + kv_head_idx * QUERY_GROUP_SIZE * HEAD_SIZE
+    query_offset += (
+        tl.arange(0, PADDED_QUERY_GROUP_SIZE)[:, None] * HEAD_SIZE
+        + tl.arange(0, HEAD_SIZE)[None, :]
+    )
+    group_mask = tl.arange(0, PADDED_QUERY_GROUP_SIZE)[:, None] < QUERY_GROUP_SIZE
+    # query: [PADDED_QUERY_GROUP_SIZE, HEAD_SIZE]
+    query = tl.load(q_ptr + query_offset, mask=group_mask, other=0.0)
+
+    # Initialize accumulators.
+    m_i = tl.zeros([PADDED_QUERY_GROUP_SIZE], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([PADDED_QUERY_GROUP_SIZE], dtype=tl.float32)
+    acc = tl.zeros([PADDED_QUERY_GROUP_SIZE, HEAD_SIZE], dtype=tl.float32)
+
+    # NOTE: KV_BLOCK_SIZE must be >= 16.
+    NUM_BLOCKS_PER_PARTITION = PARTITION_SIZE // KV_BLOCK_SIZE
+    num_prev_blocks = partition_idx * NUM_BLOCKS_PER_PARTITION
+    for i in range(num_blocks):
+        block_idx = num_prev_blocks + i
+        block_number = tl.load(
+            block_tables_ptr + seq_idx * max_num_blocks_per_seq + block_idx
+        )
+
+        # Load a key block.
+        kv_block_offset = block_number * KV_BLOCK_STRIDE + kv_offset
+        mask_offset = block_idx * KV_BLOCK_SIZE + block_offset
+        kv_mask = mask_offset[:, None] < context_len
+        # key: [KV_BLOCK_SIZE, HEAD_SIZE]
+        key = tl.load(k_cache_ptr + kv_block_offset, mask=kv_mask, other=0.0)
+
+        # Compute attention.
+        # qk: [PADDED_QUERY_GROUP_SIZE, KV_BLOCK_SIZE]
+        if PADDED_QUERY_GROUP_SIZE == 1:
+            query = tl.reshape(query, (1, HEAD_SIZE)) # tl.view for triton 2.1.0
+            qk = tl.sum(query * key, axis=1)[None, :]
+            # qk = tl.sum(query[:, None, :] * key[None, :, :], axis=2) # hang error for block_size 256
+        else:
+            qk = tl.dot(query, key.T, out_dtype=tl.float32)
+
+        qk *= attn_scale
+        qk = tl.where(mask_offset < context_len, qk, float("-inf"))
+
+        # Compute m, l, and p.
+        # m_ij: [PADDED_QUERY_GROUP_SIZE]
+        m_ij = tl.max(qk, axis=1)
+        # m_i_new: [PADDED_QUERY_GROUP_SIZE]
+        m_i_new = tl.maximum(m_i, m_ij)
+
+        # p: [PADDED_QUERY_GROUP_SIZE, KV_BLOCK_SIZE]
+        p = tl.exp(qk - m_i_new[:, None])
+        # alpha: [PADDED_QUERY_GROUP_SIZE]
+        alpha = tl.exp(m_i - m_i_new)
+        acc *= alpha[:, None]
+
+        # Load a value block.
+        # value: [KV_BLOCK_SIZE, HEAD_SIZE]
+        value = tl.load(v_cache_ptr + kv_block_offset, mask=kv_mask, other=0.0)
+
+        if PADDED_QUERY_GROUP_SIZE == 1:
+            p = tl.reshape(p, (1, KV_BLOCK_SIZE))
+            acc += tl.sum(p.T * value, axis=0)[None, :]
+            # acc += tl.sum(p.T[:, :, None] * value[:, None, :], axis=0)
+        else:
+            p = p.to(value.dtype)
+            acc += tl.dot(p, value, out_dtype=tl.float32)
+
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        m_i = m_i_new
+    acc = acc / l_i[:, None]
+
+    # Store the current partition's m and l for later reduction.
+    if USE_PARTITIONING:
+        partition_offset = (
+            (seq_idx * NUM_KV_HEADS + kv_head_idx)
+            * max_num_partitions
+            * QUERY_GROUP_SIZE
+        )
+        partition_offset += partition_idx * QUERY_GROUP_SIZE
+        partition_offset += tl.arange(0, PADDED_QUERY_GROUP_SIZE)
+        mask = tl.arange(0, PADDED_QUERY_GROUP_SIZE) < QUERY_GROUP_SIZE
+        tl.store(m_i_ptr + partition_offset, m_i, mask=mask)
+        tl.store(l_i_ptr + partition_offset, l_i, mask=mask)
+
+    # NOTE: Unlike the query tensor, we assume the out tensor is contiguous.
+    out_offset = (
+        (seq_idx * NUM_KV_HEADS + kv_head_idx)
+        * max_num_partitions
+        * QUERY_GROUP_SIZE
+        * HEAD_SIZE
+    )
+    out_offset += partition_idx * QUERY_GROUP_SIZE * HEAD_SIZE
+    out_offset += (
+        tl.arange(0, PADDED_QUERY_GROUP_SIZE)[:, None] * HEAD_SIZE
+        + tl.arange(0, HEAD_SIZE)[None, :]
+    )
+    group_mask = tl.arange(0, PADDED_QUERY_GROUP_SIZE)[:, None] < QUERY_GROUP_SIZE
+    tl.store(out_ptr + out_offset, acc, mask=group_mask)
+
+
+@triton.jit
+def _paged_attn_v2_reduce_kernel(
+    out_ptr,  # [num_seqs, NUM_KV_HEADS, QUERY_GROUP_SIZE, HEAD_SIZE]
+    m_i_ptr,  # [num_seqs, NUM_KV_HEADS, max_num_partitions, QUERY_GROUP_SIZE]
+    l_i_ptr,  # [num_seqs, NUM_KV_HEADS, max_num_partitions, QUERY_GROUP_SIZE]
+    tmp_out_ptr,  # [num_seqs, NUM_KV_HEADS, max_num_partitions, QUERY_GROUP_SIZE, HEAD_SIZE]
+    context_lens_ptr,  # [num_seqs]
+    max_num_partitions,
+    HEAD_SIZE: tl.constexpr,
+    QUERY_GROUP_SIZE: tl.constexpr,
+    NUM_KV_HEADS: tl.constexpr,
+    PARTITION_SIZE: tl.constexpr,
+    NUM_PARTITIONS: tl.constexpr,
+):
+    seq_idx = tl.program_id(0)
+    kv_head_idx = tl.program_id(1)
+
+    context_len = tl.load(context_lens_ptr + seq_idx)
+    num_partitions = tl.cdiv(context_len, PARTITION_SIZE)
+    group_head_offset = (
+        tl.arange(0, QUERY_GROUP_SIZE)[:, None] * HEAD_SIZE
+        + tl.arange(0, HEAD_SIZE)[None, :]
+    )
+    if num_partitions == 1:
+        # No reduction needed. Only copy tmp_out to out.
+        tmp_out_offset = (
+            (seq_idx * NUM_KV_HEADS + kv_head_idx)
+            * max_num_partitions
+            * QUERY_GROUP_SIZE
+            * HEAD_SIZE
+        )
+        tmp_out_offset += group_head_offset
+        tmp_out = tl.load(tmp_out_ptr + tmp_out_offset)
+        out_offset = (
+            (seq_idx * NUM_KV_HEADS + kv_head_idx) * QUERY_GROUP_SIZE * HEAD_SIZE
+        )
+        out_offset += group_head_offset
+        tl.store(out_ptr + out_offset, tmp_out)
+        return
+
+    # Get the global max logit.
+    offset = (
+        (seq_idx * NUM_KV_HEADS + kv_head_idx) * max_num_partitions * QUERY_GROUP_SIZE
+    )
+    offset += (
+        tl.arange(0, NUM_PARTITIONS)[:, None] * QUERY_GROUP_SIZE
+        + tl.arange(0, QUERY_GROUP_SIZE)[None, :]
+    )
+    mask = tl.arange(0, NUM_PARTITIONS)[:, None] < num_partitions
+    # m_i: [NUM_PARTITIONS, QUERY_GROUP_SIZE]
+    m_i = tl.load(m_i_ptr + offset, mask=mask, other=float("-inf"))
+    # m: [QUERY_GROUP_SIZE]
+    m = tl.max(m_i, axis=0)
+
+    # Rescale the exp sums and compute the global sum.
+    # l_i: [NUM_PARTITIONS, QUERY_GROUP_SIZE]
+    l_i = tl.load(l_i_ptr + offset, mask=mask, other=0.0)
+    l_i *= tl.exp(m_i - m[None, :])
+    # l: [QUERY_GROUP_SIZE]
+    l = tl.sum(l_i, axis=0)
+    # r: [NUM_PARTITIONS, QUERY_GROUP_SIZE]
+    r = l_i / l[None, :]
+
+    # Aggregate tmp_out to out.
+    tmp_out_offset = (
+        (seq_idx * NUM_KV_HEADS + kv_head_idx)
+        * max_num_partitions
+        * QUERY_GROUP_SIZE
+        * HEAD_SIZE
+    )
+    tmp_out_offset += (
+        tl.arange(0, NUM_PARTITIONS)[:, None, None] * QUERY_GROUP_SIZE * HEAD_SIZE
+    )
+    tmp_out_offset += tl.arange(0, QUERY_GROUP_SIZE)[None, :, None] * HEAD_SIZE
+    tmp_out_offset += tl.arange(0, HEAD_SIZE)[None, None, :]
+    # tmp_out: [NUM_PARTITIONS, QUERY_GROUP_SIZE, HEAD_SIZE]
+    tmp_out = tl.load(tmp_out_ptr + tmp_out_offset, mask=mask[:, :, None], other=0.0)
+    # out: [QUERY_GROUP_SIZE, HEAD_SIZE]
+    out = tl.sum((tmp_out * r[:, :, None]).to(tl.float32), axis=0)
+
+    # Store output.
+    out_offset = (seq_idx * NUM_KV_HEADS + kv_head_idx) * QUERY_GROUP_SIZE * HEAD_SIZE
+    out_offset += group_head_offset
+    tl.store(out_ptr + out_offset, out)

--- a/src/flag_attn/testing/__init__.py
+++ b/src/flag_attn/testing/__init__.py
@@ -1,4 +1,4 @@
 from flag_attn.testing.flash import attention as flash_attention # noqa: F401
 from flag_attn.testing.piecewise import attention as piecewise_attention # noqa: F401
-from flag_attn.testing.paged import paged_attention as paged_attention # noqa: F401
+from flag_attn.testing.paged import attention as paged_attention # noqa: F401
 

--- a/src/flag_attn/testing/__init__.py
+++ b/src/flag_attn/testing/__init__.py
@@ -1,2 +1,4 @@
 from flag_attn.testing.flash import attention as flash_attention # noqa: F401
 from flag_attn.testing.piecewise import attention as piecewise_attention # noqa: F401
+from flag_attn.testing.paged import paged_attention as paged_attention # noqa: F401
+

--- a/src/flag_attn/testing/paged.py
+++ b/src/flag_attn/testing/paged.py
@@ -1,0 +1,61 @@
+import math
+import torch
+
+
+def attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    # S = scale * torch.matmul(query, key.transpose(1,2)).float() qkhh khd khd
+    # P = torch.softmax(S, dim=-1).to(value.dtype)
+    # out = torch.matmul(P, value).to(query.dtype)
+    attn_weights = scale * torch.einsum("qhd,khd->hqk", query.float(), key.float())
+    attn_weights = torch.softmax(attn_weights, dim=-1)
+    out = torch.einsum("hqk,khd->qhd", attn_weights, value.float())
+    return out.to(value.dtype)
+
+def paged_attention(
+    output: torch.Tensor,
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    context_lens: torch.Tensor,
+    scale: float,
+) -> None:
+    num_query_heads = query.shape[1]
+    num_kv_heads = value_cache.shape[1]
+    num_queries_per_kv = num_query_heads // num_kv_heads
+    block_size = value_cache.shape[2]
+    head_size = value_cache.shape[3]
+    num_seqs = query.shape[0]
+
+    block_tables = block_tables.cpu().tolist()
+    context_lens = context_lens.cpu().tolist()
+    for i in range(num_seqs):
+        q = query[i].unsqueeze(0)
+        block_table = block_tables[i]
+        context_len = int(context_lens[i])
+
+        keys = []
+        values = []
+        for j in range(context_len):
+            block_number = int(block_table[j // block_size])
+            block_offset = j % block_size
+            k = key_cache[block_number, :, block_offset, :]
+            keys.append(k)
+            v = value_cache[block_number, :, block_offset, :]
+            values.append(v)
+        keys = torch.stack(keys, dim=0)
+        values = torch.stack(values, dim=0)
+        if num_queries_per_kv > 1:
+            # Handle MQA and GQA
+            keys = torch.repeat_interleave(keys, num_queries_per_kv, dim=1)
+            values = torch.repeat_interleave(values, num_queries_per_kv, dim=1)
+
+        out = attention(q, keys, values, scale)
+        out = out.view(num_query_heads, head_size)
+        output[i].copy_(out, non_blocking=True)
+

--- a/tests/flag_attn/test_paged_attention.py
+++ b/tests/flag_attn/test_paged_attention.py
@@ -13,7 +13,6 @@ def base_paged_attention(
     head_size,
     block_size,
     max_seq_len,
-    partition_size=256,
     num_splits=0,
     dtype=torch.float16,
     device="cuda",
@@ -48,7 +47,6 @@ def base_paged_attention(
         block_tables,
         attn_scale,
         max_context_len,
-        partition_size,
         num_splits,
     )
 
@@ -68,7 +66,7 @@ def base_paged_attention(
 @pytest.mark.parametrize("num_query_heads", [64])
 @pytest.mark.parametrize("query_group_size", [1, 8])
 @pytest.mark.parametrize("head_size", [64, 128])
-@pytest.mark.parametrize("block_size", [16, 256])
+@pytest.mark.parametrize("block_size", [16, 128, 256])
 @pytest.mark.parametrize("max_seq_len", [512, 4096])
 def test_paged_attention_default(
     num_seqs,
@@ -87,35 +85,6 @@ def test_paged_attention_default(
         head_size,
         block_size,
         max_seq_len,
-    )
-
-
-@pytest.mark.parametrize("num_seqs", [1, 32])
-@pytest.mark.parametrize("num_query_heads", [64])
-@pytest.mark.parametrize("query_group_size", [1, 8])
-@pytest.mark.parametrize("head_size", [64, 128])
-@pytest.mark.parametrize("block_size", [32])
-@pytest.mark.parametrize("max_seq_len", [2048])
-@pytest.mark.parametrize("partition_size", [32, 128, 256])
-def test_paged_attention_by_partition_size(
-    num_seqs,
-    num_query_heads,
-    query_group_size,
-    head_size,
-    block_size,
-    max_seq_len,
-    partition_size,
-    dtype=torch.float16,
-    device="cuda",
-):
-    base_paged_attention(
-        num_seqs,
-        num_query_heads,
-        query_group_size,
-        head_size,
-        block_size,
-        max_seq_len,
-        partition_size,
     )
 
 

--- a/tests/flag_attn/test_paged_attention.py
+++ b/tests/flag_attn/test_paged_attention.py
@@ -1,0 +1,84 @@
+import torch
+import pytest
+
+import triton
+import triton.language as tl
+
+import flag_attn
+
+# from paged import paged_attention
+# from testing.paged import paged_attention as torch_paged_attention
+
+
+NUM_BLOCKS = 1000
+
+@pytest.mark.parametrize('num_seqs', [1, 32])
+@pytest.mark.parametrize('num_query_heads', [64])
+@pytest.mark.parametrize('query_group_size', [1, 8])
+@pytest.mark.parametrize('head_size', [64])
+@pytest.mark.parametrize('block_size', [16, 256])
+@pytest.mark.parametrize('max_seq_len', [4096])
+@pytest.mark.parametrize('version', [1, 2])
+def test_paged_attention(
+    num_seqs,
+    num_query_heads,
+    query_group_size,
+    head_size,
+    block_size,
+    max_seq_len,
+    version,
+    dtype=torch.float16,
+    device="cuda",
+):
+    torch.set_default_dtype(dtype)
+    torch.set_default_device(device=device)
+
+    # torch.cuda.manual_seed(seed)
+
+    num_kv_heads = num_query_heads // query_group_size
+    # QUERY_GROUP_SIZE = num_query_heads // num_kv_heads
+    
+    # 初始化每个 seq 的长度
+    context_lens = torch.randint(1, max_seq_len, [num_seqs],dtype=torch.int32)
+    max_context_len = context_lens.max().item()
+    max_num_blocks_per_seq = (max_context_len + block_size - 1) // block_size
+
+    attn_scale = head_size ** -0.5
+    q = torch.empty(num_seqs, num_query_heads, head_size)
+    q.uniform_(-attn_scale, attn_scale)
+    out = torch.empty_like(q)
+
+    k_cache = torch.empty(NUM_BLOCKS, num_kv_heads,block_size, head_size)
+    k_cache.uniform_(-attn_scale, attn_scale)
+    v_cache = torch.empty_like(k_cache)
+    v_cache.uniform_(-attn_scale, attn_scale)
+
+    # (NUM_SEQS, MAX_NUM_BLOCKS_PER_SEQ)
+    block_tables = torch.randint(
+        0, NUM_BLOCKS, (num_seqs, max_num_blocks_per_seq))
+    
+    print("version: ",version)
+    flag_attn.paged_attention(
+        out,
+        q,
+        k_cache,
+        v_cache,
+        context_lens,
+        block_tables,
+        attn_scale,
+        max_context_len,
+        version = version,
+    )
+
+    ref_out = torch.empty_like(out)
+    flag_attn.testing.paged_attention(
+        ref_out,
+        q,
+        k_cache,
+        v_cache,
+        block_tables,
+        context_lens,
+        attn_scale,
+    )
+    print(torch.abs(out - ref_out).max())
+    assert torch.allclose(out, ref_out, atol=1e-3, rtol=1e-5)

--- a/tests/flag_attn/test_paged_attention.py
+++ b/tests/flag_attn/test_paged_attention.py
@@ -59,7 +59,7 @@ def base_paged_attention(
         attn_scale,
     )
     print(torch.abs(out - ref_out).max())
-    assert torch.allclose(out, ref_out, atol=1e-3, rtol=1e-5)
+    assert torch.allclose(out, ref_out, atol=2e-3, rtol=1e-5)
 
 
 @pytest.mark.parametrize("num_seqs", [1, 32])
@@ -88,10 +88,10 @@ def test_paged_attention_default(
     )
 
 
-@pytest.mark.parametrize("num_seqs", [1, 32])
+@pytest.mark.parametrize("num_seqs", [1, 16])
 @pytest.mark.parametrize("num_query_heads", [64])
 @pytest.mark.parametrize("query_group_size", [1, 8])
-@pytest.mark.parametrize("head_size", [64, 128])
+@pytest.mark.parametrize("head_size", [32, 64])
 @pytest.mark.parametrize("block_size", [16])
 @pytest.mark.parametrize("max_seq_len", [2048])
 @pytest.mark.parametrize("num_splits", [1, 2, 3, 4, 5, 6, 7, 8])
@@ -114,4 +114,30 @@ def test_paged_attention_by_num_splits(
         block_size,
         max_seq_len,
         num_splits=num_splits,
+    )
+
+@pytest.mark.parametrize("num_seqs, num_query_heads, query_group_size, head_size, block_size, max_seq_len, num_splits", [
+    (1, 12, 1, 64, 16, 2, 0),
+    (16, 64, 8, 32, 16, 2048, 2),
+    (16, 64, 1, 64, 16, 2048, 6),
+])
+def test_paged_attention_by_case(
+    num_seqs,
+    num_query_heads,
+    query_group_size,
+    head_size,
+    block_size,
+    max_seq_len,
+    num_splits,
+    dtype=torch.float16,
+    device="cuda",
+):
+    base_paged_attention(
+        num_seqs,
+        num_query_heads,
+        query_group_size,
+        head_size,
+        block_size,
+        max_seq_len,
+        num_splits,
     )


### PR DESCRIPTION
1. Add paged attention operation commonly used in large language model inference. About paged attention view https://arxiv.org/pdf/2309.06180.pdf.
2. This implementation requires triton 2.2.0.


There is some performance data between triton and vllm.
```
vllm_paged_attention-B32-G8-D128-bs16-v2:
   context_len     triton  vllm-0.3.0
0        512.0   6.618643    3.582180
1       1024.0   7.798634    3.925020
2       2048.0   8.560921    4.286430
3       4096.0  12.241113    4.460762
4       8192.0  13.589705    4.558541
5      16384.0  14.094599    4.609148
```
Note:
- Input layout is different, performance is for reference only.
- Some input shapes is still being optimized.