### PR TITLE
support grouped query attention(MQA & GQA) for flash_attn

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ The performance of piecewise_attention has improved compared to that in v0.1. In
 - the sequence length of k/v can be different from that of q;
 - support computation of total attention of each `k` gets from all `q`'s;
 - supports returning accumulative attention of each keys.
+- supports [MQA](https://arxiv.org/abs/1911.02150) and [GQA](https://arxiv.org/pdf/2305.13245).
 
 #### Limitations
 

--- a/src/flag_attn/flash.py
+++ b/src/flag_attn/flash.py
@@ -232,21 +232,24 @@ def attention(q, k, v, causal=False, sm_scale=None,
     An implementation of FlashAttention v2(https://arxiv.org/abs/2307.08691).
 
     Arguments:
-        q(torch.Tensor): The first queries. The shape is (batch_size, nheads, seqlen_q, headdim).
-        k(torch.Tensor): The first keys. The shape is (batch_size, nheads, seqlen_k, headdim).
-        v(torch.Tensor): The values. The shape is (batch_size, nheads, seqlen_k, headdim).
+        q(torch.Tensor): The first queries. The shape is (batch_size, num_heads_q, seqlen_q, headdim).
+        k(torch.Tensor): The first keys. The shape is (batch_size, num_heads_k, seqlen_k, headdim).
+        v(torch.Tensor): The values. The shape is (batch_size, num_heads_k, seqlen_k, headdim).
         causal(bool): Whether causal masking is applied to attention scores before applying softmax.
         sm_scale(float): The scaling of attention scores before applying softmax.
         return_log_normalizer(bool): Whether to return the log normalizer of softmax inside attention.
         return_total_attention(bool): Whether to return the sum of attention along q's sequence dimendion.
 
     Returns:
-        out(torch.Tensor): The output. The shape is (batch_size, nheads, seqlen_q, headdim).
+        out(torch.Tensor): The output. The shape is (batch_size, num_heads_q, seqlen_q, headdim).
 
         If `return_log_normalizer` or `return_total_attention`, return the following results in addition.
 
-        log_normalizer(torch.Tensor): The log normalizer. The shape is (batch_size, nheads, seqlen_q).
-        total_attention(torch.Tensor): The total attention. The shape is (batch_size, nheads, seqlen_k).
+        log_normalizer(torch.Tensor): The log normalizer. The shape is (batch_size, num_heads_q, seqlen_q).
+        total_attention(torch.Tensor): The total attention. The shape is (batch_size, num_heads_q, seqlen_k).
+
+    Notes:
+        `num_heads_q` must be a multiple of `num_heads_k`.
     """
     return FlashAttention.apply(q, k, v, causal, sm_scale, return_log_normalizer, return_total_attention)
 

--- a/src/flag_attn/testing/flash.py
+++ b/src/flag_attn/testing/flash.py
@@ -16,6 +16,15 @@ def attention(q,
     D = q.shape[-1]
     if sm_scale is None:
         sm_scale = 1. / math.sqrt(D)
+
+    num_heads_q = q.shape[1]
+    num_heads_k = k.shape[1]
+    assert num_heads_q % num_heads_k == 0
+    num_groups = num_heads_q // num_heads_k
+
+    if num_groups > 1:
+        k = torch.repeat_interleave(k, repeats=num_groups, dim=1)
+        v = torch.repeat_interleave(v, repeats=num_groups, dim=1)
     kv_seq_len = k.shape[-2]
     q_seq_len = q.shape[-2]
     p_seq = kv_seq_len - q_seq_len


### PR DESCRIPTION
support grouped query attention(GQA) for flash_attn(related kernels: fwd, bwd, split_kv, total_attention)

The MQA paper

> Shazeer, Noam. “Fast Transformer Decoding: One Write-Head Is All You Need.” arXiv, November 5, 2019. https://doi.org/10.48550/arXiv.1911.02150.


The GQA paper 

> Ainslie, Joshua, James Lee-Thorp, Michiel de Jong, Yury Zemlyanskiy, Federico Lebrón, and Sumit Sanghai. “GQA: Training Generalized Multi-Query Transformer Models from Multi-Head Checkpoints.” arXiv, December 23, 2023.

Mind the layout of the heads in the query.