### PR TITLE
Supporting memory efficient dropout in flash attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,11 +234,11 @@ The performance of piecewise_attention has improved compared to that in v0.1. In
 - support computation of total attention of each `k` gets from all `q`'s;
 - supports returning accumulative attention of each keys.
 - supports [MQA](https://arxiv.org/abs/1911.02150) and [GQA](https://arxiv.org/pdf/2305.13245).
+- supports dropout of attention weights.
 
 #### Limitations
 
 - `headdim` should be in `[16, 32, 64, 128]`.
-- dropout of attention weights is not supported yet.
 
 ## TODOs
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -224,11 +224,12 @@ print(gq)
 - 支持前向和反向计算；
 - K/V 的序列长度可以不等于 Q 的序列长度；
 - 支持计算每个 k 从所有 q 得到的 attention 总和。
+- 支持 [MQA](https://arxiv.org/abs/1911.02150) and [GQA](https://arxiv.org/pdf/2305.13245).
+- 支持对 attention weights 进行 dropout.
 
 #### 限制
 
 - `headdim` 必须为 `[16, 32, 64, 128]` 之一；
-- 尚未支持对 attention weight 使用 dropout。
 
 ## TODOs
 

--- a/src/flag_attn/dropout.py
+++ b/src/flag_attn/dropout.py
@@ -13,25 +13,3 @@ def philox_cuda_seed_offset(increment, device=None):
     # get_state returns a new tensor, so it needs set_state to update the actual generator state.
     gen.set_state(state_copy)
     return seed, offset
-
-@triton.jit
-def dropout_mask_kernel(dropout_mask, B, H, M, N, dropout_p, seed, offset):
-    row, b, h = tl.program_id(0), tl.program_id(1), tl.program_id(2)
-    offs_base = b * H * M * N + h * M * N + row * N
-    BLOCK: tl.constexpr = 1024
-    offs_base += tl.arange(0, BLOCK)
-    for start_n in range(0, N, BLOCK):
-        offs = start_n + offs_base
-        rng_offs = offset + offs
-        pmask = tl.rand(seed, rng_offs, n_rounds=6) > dropout_p
-        row_mask = start_n + tl.arange(0, BLOCK) < N
-        tl.store(dropout_mask + offs, pmask, mask=row_mask)
-
-def dropout_mask(x, B, H, M, N, dropout_p, seed, offset):
-    dropout_mask = torch.full((B, H, M, N), True, dtype=torch.bool, device=x.device)
-    if dropout_p == 0:
-        return dropout_mask
-    grid = (M, B, H)
-    with torch.cuda.device(x.device):
-        dropout_mask_kernel[grid](dropout_mask, B, H, M, N, dropout_p, seed, offset)
-    return dropout_mask

--- a/src/flag_attn/dropout.py
+++ b/src/flag_attn/dropout.py
@@ -32,6 +32,6 @@ def dropout_mask(x, B, H, M, N, dropout_p, seed, offset):
     if dropout_p == 0:
         return dropout_mask
     grid = (M, B, H)
-    dropout_mask_kernel[grid](dropout_mask, B, H, M, N, dropout_p, seed, offset)
+    with torch.cuda.device(x.device):
+        dropout_mask_kernel[grid](dropout_mask, B, H, M, N, dropout_p, seed, offset)
     return dropout_mask
-

--- a/src/flag_attn/dropout.py
+++ b/src/flag_attn/dropout.py
@@ -1,0 +1,15 @@
+import torch
+
+def philox_cuda_seed_offset(increment, device=None):
+    device = device or torch.cuda.current_device()
+    gen = torch.cuda.default_generators[device]
+    state_copy = gen.get_state()
+    c0, c1 = state_copy.view(torch.int64)
+    seed, offset = int(c0), int(c1)
+    increment = (increment + 3) // 4 * 4
+    c1 += increment
+    # get_state returns a new tensor, so it needs set_state to update the actual generator state.
+    gen.set_state(state_copy)
+    return seed, offset
+
+

--- a/src/flag_attn/flash.py
+++ b/src/flag_attn/flash.py
@@ -717,7 +717,7 @@ def _bwd_kv_kernel(
         if IS_DROPOUT:
             dv += tl.dot(tl.trans(p_masked), do) * rp # (BLOCK_N, BLOCK_DMODEL)  # still correct
         else:
-            dv += tl.dot(tl.trans(p), do) # (BLOCK_N, BLOCK_DMODEL)  # still correct
+            dv += tl.dot(tl.trans(p).to(input_dtype), do) # (BLOCK_N, BLOCK_DMODEL)  # still correct
 
         # compute dp = dot(v, do)
         if DIVISIBLE_M:

--- a/src/flag_attn/testing/__init__.py
+++ b/src/flag_attn/testing/__init__.py
@@ -1,4 +1,4 @@
 from flag_attn.testing.flash import attention as flash_attention # noqa: F401
 from flag_attn.testing.piecewise import attention as piecewise_attention # noqa: F401
 from flag_attn.testing.paged import attention as paged_attention # noqa: F401
-
+from flag_attn.testing.dropout import recompute_mask

--- a/src/flag_attn/testing/dropout.py
+++ b/src/flag_attn/testing/dropout.py
@@ -1,0 +1,25 @@
+import torch
+import triton
+import triton.language as tl
+
+@triton.jit
+def recompute_mask_kernel(mask, B, H, M, N, dropout_p, seed, offset):
+    row, b, h = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    offs_base = b * H * M * N + h * M * N + row * N
+    BLOCK: tl.constexpr = 1024
+    offs_base += tl.arange(0, BLOCK)
+    for start_n in range(0, N, BLOCK):
+        offs = start_n + offs_base
+        rng_offs = offset + offs
+        pmask = tl.rand(seed, rng_offs, n_rounds=6) > dropout_p
+        row_mask = start_n + tl.arange(0, BLOCK) < N
+        tl.store(mask + offs, pmask, mask=row_mask)
+
+def recompute_mask(B, H, M, N, dropout_p, seed, offset, device):
+    mask = torch.full((B, H, M, N), True, dtype=torch.bool, device=device)
+    if dropout_p == 0:
+        return mask
+    grid = (M, B, H)
+    with torch.cuda.device(device):
+        recompute_mask_kernel[grid](mask, B, H, M, N, dropout_p, seed, offset)
+    return mask

--- a/src/flag_attn/testing/flash.py
+++ b/src/flag_attn/testing/flash.py
@@ -1,10 +1,13 @@
 import math
 import torch
 
+
 def attention(q,
               k,
               v,
               causal,
+              dropout_p=0.0,
+              dropout_mask=None,
               sm_scale=None,
               return_log_normalizer=False,
               return_total_attention=False,
@@ -40,13 +43,22 @@ def attention(q,
     if return_total_attention:
         tot_attn = torch.sum(P, dim=-2)
 
-    attn_output = torch.matmul(P.to(v.dtype), v).to(input_dtype)
+    # Applies dropout
+    dropout_scaling = 1.0 / (1 - dropout_p)
+    if dropout_mask is not None:
+        P_dropout = P.masked_fill(~dropout_mask, 0.0)
+        # P = P.masked_fill(~dropout_mask, 0.0)
+
+    # attn_output = torch.matmul(P.to(v.dtype), v * dropout_scaling).to(input_dtype)
+    attn_output = torch.matmul(P_dropout.to(v.dtype), v * dropout_scaling).to(input_dtype)
 
     has_extra_return = return_log_normalizer or return_total_attention
     if has_extra_return:
         outs = (attn_output,
-                 log_normalizer if return_log_normalizer else None,
-                 tot_attn if return_total_attention else None)
+                P,
+                P_dropout,
+                log_normalizer if return_log_normalizer else None,
+                tot_attn if return_total_attention else None)
         return outs
     else:
-        return attn_output
+        return attn_output, P, P_dropout

--- a/src/flag_attn/testing/flash.py
+++ b/src/flag_attn/testing/flash.py
@@ -43,22 +43,18 @@ def attention(q,
     if return_total_attention:
         tot_attn = torch.sum(P, dim=-2)
 
-    # Applies dropout
+    # Applies dropout 
     dropout_scaling = 1.0 / (1 - dropout_p)
     if dropout_mask is not None:
-        P_dropout = P.masked_fill(~dropout_mask, 0.0)
-        # P = P.masked_fill(~dropout_mask, 0.0)
+        P = P.masked_fill(~dropout_mask, 0.0)
 
-    # attn_output = torch.matmul(P.to(v.dtype), v * dropout_scaling).to(input_dtype)
-    attn_output = torch.matmul(P_dropout.to(v.dtype), v * dropout_scaling).to(input_dtype)
+    attn_output = torch.matmul(P.to(v.dtype), v * dropout_scaling).to(input_dtype)
 
     has_extra_return = return_log_normalizer or return_total_attention
     if has_extra_return:
         outs = (attn_output,
-                P,
-                P_dropout,
                 log_normalizer if return_log_normalizer else None,
                 tot_attn if return_total_attention else None)
         return outs
     else:
-        return attn_output, P, P_dropout
+        return attn_output

--- a/tests/flag_attn/test_dropout.py
+++ b/tests/flag_attn/test_dropout.py
@@ -1,0 +1,29 @@
+import torch
+import pytest
+from flag_attn.dropout import dropout_mask
+
+@pytest.mark.parametrize('x', [torch.empty(1, device='cuda')])
+@pytest.mark.parametrize('B, H, M, N', [
+    (2, 4, 512, 612),
+    (2, 4, 1024, 1034),
+    (2, 4, 2048, 2048),
+    (2, 4, 4096, 4096),
+    (2, 4, 4001, 4001),
+    (2, 4, 4001, 4096),
+    (2, 4, 4096, 4000),
+    (1, 2, 8192, 8202),
+    (1, 2, 8192, 8192),
+])
+@pytest.mark.parametrize('p', [0.5, 0.8])
+def test_dropout_mask(x, B, H, M, N, p):
+    import math
+    seed = 123456789
+    offset = 123456789123456789
+    mask = dropout_mask(x, B, H, M, N, p, seed, offset)
+    # zeros indicate to drop
+    # k follows Binomial distributio B(k; n, p)
+    n = mask.numel()
+    k = torch.sum(mask == 0)
+    p_cap = k / n
+    tol = 0.01
+    assert math.fabs(p_cap - p) < tol * p

--- a/tests/flag_attn/test_dropout.py
+++ b/tests/flag_attn/test_dropout.py
@@ -1,8 +1,8 @@
 import torch
 import pytest
-from flag_attn.dropout import dropout_mask
+from flag_attn.testing import recompute_mask
 
-@pytest.mark.parametrize('x', [torch.empty(1, device='cuda')])
+
 @pytest.mark.parametrize('B, H, M, N', [
     (2, 4, 512, 612),
     (2, 4, 1024, 1034),
@@ -15,11 +15,12 @@ from flag_attn.dropout import dropout_mask
     (1, 2, 8192, 8192),
 ])
 @pytest.mark.parametrize('p', [0.5, 0.8])
-def test_dropout_mask(x, B, H, M, N, p):
+def test_recompute_mask(B, H, M, N, p):
     import math
     seed = 123456789
     offset = 123456789123456789
-    mask = dropout_mask(x, B, H, M, N, p, seed, offset)
+    device = torch.cuda.current_device()
+    mask = recompute_mask(B, H, M, N, p, seed, offset, device)
     # zeros indicate to drop
     # k follows Binomial distributio B(k; n, p)
     n = mask.numel()

--- a/tests/flag_attn/test_flash_attention.py
+++ b/tests/flag_attn/test_flash_attention.py
@@ -295,7 +295,7 @@ def test_attention_bwd_dropout(B, H, M, N, D, causal, dropout_p, stride_order, d
         v = torch.empty((B, N, H, D), dtype=dtype, device=device).normal_(mean=0., std=scale).transpose(1, 2).requires_grad_()
         do = torch.randn((B, M, H, D), dtype=dtype, device=device).transpose(1, 2)
 
-    
+
     from flag_attn.dropout import dropout_mask
     # from flag_attn.dropout import philox_cuda_seed_offset
     # philox_cuda_seed_offset(increment)

--- a/tests/flag_attn/test_flash_attention.py
+++ b/tests/flag_attn/test_flash_attention.py
@@ -206,7 +206,7 @@ def test_attention_with_aux_outs(B, H, M, N, D, causal, stride_order, dtype, sca
 
     o_ref, log_norm_ref, tot_attn_ref = flag_attn.testing.flash_attention(q, k, v, causal, return_log_normalizer=True, return_total_attention=True, upcast=True)
     o_torch, log_norm_torch, tot_attn_torch = flag_attn.testing.flash_attention(q, k, v, causal, return_log_normalizer=True, return_total_attention=True, upcast=False)
-    o_hyp, log_norm_hyp, tot_attn_hyp = flag_attn.flash_attention(q, k, v, causal, return_log_normalizer=True, return_total_attention=True)
+    o_hyp, log_norm_hyp, tot_attn_hyp, *_ = flag_attn.flash_attention(q, k, v, causal, return_log_normalizer=True, return_total_attention=True)
 
 
     torch_max_diff = max_diff(o_torch, o_ref)

--- a/tests/flag_attn/test_flash_attention.py
+++ b/tests/flag_attn/test_flash_attention.py
@@ -190,3 +190,43 @@ def test_attention_with_aux_outs(B, H, M, N, D, causal, stride_order, dtype, sca
     triton_max_diff = max_diff(tot_attn_hyp, tot_attn_ref)
     assert triton_max_diff <= 2 * torch_max_diff + 1e-5
 
+
+@pytest.mark.parametrize('device_id', list(range(torch.cuda.device_count())))
+@pytest.mark.parametrize('scale', [1.0, 2.0])
+@pytest.mark.parametrize('B, H, M, N, D', [
+    (2, 4, 512, 612, 128),
+    (2, 4, 1024, 1034, 64),
+    (2, 4, 2048, 2048, 32),
+    # (2, 4, 4096, 4096, 16),
+    # (2, 4, 4001, 4001, 32),
+    # (2, 4, 4001, 4096, 64),
+    # (2, 4, 4096, 4000, 128),
+    # (1, 2, 8192, 8202, 16),
+    # (1, 2, 8192, 8192, 32),
+])
+@pytest.mark.parametrize('causal', [False, True])
+@pytest.mark.parametrize('dropout_p', [0.5, 0.8])
+@pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize('stride_order', ['BHTD'])
+def test_attention_dropout(B, H, M, N, D, causal, dropout_p, stride_order, dtype, scale, device_id):
+    device = f"cuda:{device_id}"
+    if stride_order == "BHTD":
+        q = torch.empty((B, H, M, D), dtype=dtype, device=device).normal_(mean=0., std=scale)
+        k = torch.empty((B, H, N, D), dtype=dtype, device=device).normal_(mean=0., std=scale)
+        v = torch.empty((B, H, N, D), dtype=dtype, device=device).normal_(mean=0., std=scale)
+    else:
+        q = torch.empty((B, M, H, D), dtype=dtype, device=device).normal_(mean=0., std=scale).transpose(1, 2)
+        k = torch.empty((B, N, H, D), dtype=dtype, device=device).normal_(mean=0., std=scale).transpose(1, 2)
+        v = torch.empty((B, N, H, D), dtype=dtype, device=device).normal_(mean=0., std=scale).transpose(1, 2)
+
+    from flag_attn.dropout import dropout_mask
+    o_hyp, p_hyp, _, _, seed, offset = flag_attn.flash_attention(q, k, v, causal, dropout_p=dropout_p, return_seed_offset=True)
+    mask = dropout_mask(q, B, H, M, N, dropout_p, seed, offset)
+    o_ref, P_ref, P_dropout_ref = flag_attn.testing.flash_attention(q, k, v, causal, dropout_p=dropout_p, dropout_mask=mask, upcast=True)
+    o_torch, P_torch, P_dropout_torch = flag_attn.testing.flash_attention(q, k, v, causal, dropout_p=dropout_p, dropout_mask=mask, upcast=False)
+
+    torch_max_diff = max_diff(o_torch, o_ref)
+    triton_max_diff = max_diff(o_hyp, o_ref)
+    report("o hyp", o_hyp, o_ref)
+    report("o torch", o_torch, o_ref)
+    assert triton_max_diff <= 2 * torch_max_diff + 1e-5


### PR DESCRIPTION
The main difference from Tri Dao's cuda implementation is the way we handle philox rng state.  We cannot easily control the per thread philox offset increment since Triton makes thread abstraction opaque. That means we cannot reproduce the dropout masks exactly the same way as the cuda version. 
The second difference is about the nuances of where to apply scaling, masking, casting and everything. It's an experience not guided by principles but rather trial and error. 
 