### PR TITLE
fix: include flag_attn subpackages in built distributions

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -52,8 +52,13 @@ override_dh_auto_test:
 	for d in .pybuild/cpython3_*/build; do \
 	    if [ -d "$$d/flag_attn" ]; then found_dir="$$d"; break; fi; \
 	done; \
+	src_inits="$$(cd src && find flag_attn -name __init__.py)"; \
+	if [ -z "$$src_inits" ]; then \
+	    echo "ERROR: no __init__.py found under src/flag_attn; check would be vacuous"; \
+	    exit 1; \
+	fi; \
 	missing=""; \
-	for f in $$(cd src && find flag_attn -name __init__.py); do \
+	for f in $$src_inits; do \
 	    if [ ! -f "$$found_dir/$$f" ]; then missing="$$missing $$f"; fi; \
 	done; \
 	if [ -n "$$missing" ]; then \

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -40,4 +40,25 @@ override_dh_auto_test:
 	echo "Found build dir: $$found_dir"; \
 	PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$$found_dir" python3 -c \
 	    "import importlib.util; s = importlib.util.find_spec('flag_attn'); assert s and s.origin, 'flag_attn not findable'; print('OK: flag_attn at', s.origin)"
+# Subpackage completeness: compare the __init__.py sets between src/ and
+# the build tree. Catches packages.find configs that silently drop
+# subpackages (include = ["flag_attn"] matched only the top level, so the
+# shipped deb failed `import flag_attn` on the missing flag_attn.testing).
+# Filesystem check on purpose: find_spec on a subpackage would import
+# flag_attn/__init__.py, which needs torch/triton — not available (and
+# not wanted) in the build environment.
+	@echo "=== subpackage completeness test ==="
+	@found_dir=""; \
+	for d in .pybuild/cpython3_*/build; do \
+	    if [ -d "$$d/flag_attn" ]; then found_dir="$$d"; break; fi; \
+	done; \
+	missing=""; \
+	for f in $$(cd src && find flag_attn -name __init__.py); do \
+	    if [ ! -f "$$found_dir/$$f" ]; then missing="$$missing $$f"; fi; \
+	done; \
+	if [ -n "$$missing" ]; then \
+	    echo "ERROR: subpackages missing from build tree:$$missing"; \
+	    exit 1; \
+	fi; \
+	echo "OK: all package __init__.py files from src/ present in build tree"
 

--- a/packaging/rpm/specs/flag-attention.spec
+++ b/packaging/rpm/specs/flag-attention.spec
@@ -50,6 +50,26 @@ export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
 PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPATH=%{buildroot}%{python3_sitelib} \
     python3 -c "import importlib.util; s = importlib.util.find_spec('flag_attn'); assert s and s.origin, 'flag_attn not findable'; print('OK: flag_attn at', s.origin)"
+# Subpackage completeness: compare the __init__.py sets between src/ and
+# the installed buildroot. Catches packages.find configs that silently
+# drop subpackages (same check as in packaging/debian/rules). Filesystem
+# check on purpose: find_spec on a subpackage would import
+# flag_attn/__init__.py, which needs torch/triton — not available (and
+# not wanted) in the build environment.
+src_inits="$(cd src && find flag_attn -name __init__.py)"
+if [ -z "$src_inits" ]; then
+    echo "ERROR: no __init__.py found under src/flag_attn; check would be vacuous"
+    exit 1
+fi
+missing=""
+for f in $src_inits; do
+    if [ ! -f "%{buildroot}%{python3_sitelib}/$f" ]; then missing="$missing $f"; fi
+done
+if [ -n "$missing" ]; then
+    echo "ERROR: subpackages missing from buildroot:$missing"
+    exit 1
+fi
+echo "OK: all package __init__.py files from src/ present in buildroot"
 
 %files -f %{pyproject_files}
 %license LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ version_file = "src/flag_attn/_version.py"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["flag_attn"]
+include = ["flag_attn*"]
 namespaces = false
 
 # helps for setting up pytest in pyprojects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ version_file = "src/flag_attn/_version.py"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["flag_attn*"]
+include = ["flag_attn", "flag_attn.*"]
 namespaces = false
 
 # helps for setting up pytest in pyprojects


### PR DESCRIPTION
`packages.find` with `include = ["flag_attn"]` only matches the top-level package, so `flag_attn.testing` is missing from built wheels/debs and `import flag_attn` fails after install.

- pyproject.toml: `include = ["flag_attn*"]`
- packaging/debian/rules: add a subpackage completeness check to the smoke test

Verified on ubuntu 24.04: the fixed build passes and the deb contains `flag_attn/testing/`; with the fix reverted, the new check fails the build.