### PR TITLE
Add optimized GDN forward operator

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -52,7 +52,7 @@ jobs:
   build:
     needs: detect-changes
     if: needs.detect-changes.outputs.run_tests == 'true'
-    runs-on: self-hosted
+    runs-on: h20
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -70,14 +70,35 @@ jobs:
     #     if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     #     pip install .
 
-    - name: Activate Virtualenv
+    - name: Activate Python environment
+      shell: bash
       run: |
-        source /home/flagattn_ci/.virtualenvs/release/bin/activate
-        echo PATH=$PATH >> $GITHUB_ENV
+        set -euo pipefail
+
+        venv=""
+        shopt -s nullglob
+        for candidate in \
+          /home/flagattn_ci/.virtualenvs/release \
+          "$HOME/.virtualenvs/release" \
+          /home/*/.virtualenvs/release; do
+          if [ -x "$candidate/bin/python" ]; then
+            venv="$candidate"
+            break
+          fi
+        done
+
+        if [ -z "$venv" ]; then
+          venv="$RUNNER_TEMP/flagattention-venv"
+          python3 -m venv --system-site-packages "$venv"
+        fi
+
+        echo "$venv/bin" >> "$GITHUB_PATH"
+        "$venv/bin/python" -c "import torch, triton"
+        "$venv/bin/python" -c "import pytest" || "$venv/bin/python" -m pip install "pytest>=7.1.0"
 
     - name: Editable Install
       run: |
-        pip install --no-dependencies -e .
+        python -m pip install --no-dependencies -e .
 
     # - name: Lint with flake8
     #   run: |
@@ -87,4 +108,4 @@ jobs:
     #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest tests
+        python -m pytest tests

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -70,35 +70,54 @@ jobs:
     #     if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     #     pip install .
 
-    - name: Activate Python environment
+    - name: Select Python environment
       shell: bash
       run: |
         set -euo pipefail
 
-        venv=""
         shopt -s nullglob
-        for candidate in \
-          /home/flagattn_ci/.virtualenvs/release \
-          "$HOME/.virtualenvs/release" \
-          /home/*/.virtualenvs/release; do
-          if [ -x "$candidate/bin/python" ]; then
-            venv="$candidate"
+        candidates=(
+          /home/flagattn_ci/.virtualenvs/release/bin/python
+          "$HOME"/.virtualenvs/*/bin/python
+          /home/*/.virtualenvs/*/bin/python
+          /home/*/.venvs/*/bin/python
+          /home/*/miniconda*/bin/python
+          /home/*/miniconda*/envs/*/bin/python
+          /home/*/anaconda*/bin/python
+          /home/*/anaconda*/envs/*/bin/python
+          /opt/conda/bin/python
+          /opt/conda/envs/*/bin/python
+        )
+        candidates+=("$(command -v python3 || true)" "$(command -v python || true)")
+
+        python_bin=""
+        for candidate in "${candidates[@]}"; do
+          if [ -x "$candidate" ] && "$candidate" -c "import torch, triton" >/dev/null 2>&1; then
+            python_bin="$candidate"
             break
           fi
         done
 
-        if [ -z "$venv" ]; then
-          venv="$RUNNER_TEMP/flagattention-venv"
-          python3 -m venv --system-site-packages "$venv"
+        if [ -z "$python_bin" ]; then
+          echo "No Python environment with torch and triton was found." >&2
+          printf 'Checked: %s\n' "${candidates[@]}" >&2
+          exit 1
         fi
 
-        echo "$venv/bin" >> "$GITHUB_PATH"
-        "$venv/bin/python" -c "import torch, triton"
-        "$venv/bin/python" -c "import pytest" || "$venv/bin/python" -m pip install "pytest>=7.1.0"
+        if ! "$python_bin" -c "import pytest" >/dev/null 2>&1; then
+          venv="$RUNNER_TEMP/flagattention-venv"
+          "$python_bin" -m venv --system-site-packages "$venv"
+          "$venv/bin/python" -m pip install "pytest>=7.1.0"
+          python_bin="$venv/bin/python"
+        fi
 
-    - name: Editable Install
-      run: |
-        python -m pip install --no-dependencies -e .
+        echo "$(dirname "$python_bin")" >> "$GITHUB_PATH"
+        "$python_bin" -c "import torch, triton, pytest; print(torch.__version__, triton.__version__)"
+
+    - name: Verify source import
+      env:
+        PYTHONPATH: src
+      run: python -c "import flag_attn"
 
     # - name: Lint with flake8
     #   run: |

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -99,9 +99,11 @@ jobs:
         done
 
         if [ -z "$python_bin" ]; then
-          echo "No Python environment with torch and triton was found." >&2
-          printf 'Checked: %s\n' "${candidates[@]}" >&2
-          exit 1
+          venv="$RUNNER_TEMP/flagattention-venv"
+          python3 -m venv "$venv"
+          python_bin="$venv/bin/python"
+          "$python_bin" -m pip install --upgrade pip
+          "$python_bin" -m pip install "torch" "triton>=2.2.0" "pytest>=7.1.0"
         fi
 
         if ! "$python_bin" -c "import pytest" >/dev/null 2>&1; then

--- a/benchmark/gated_delta_rule_benchmark.py
+++ b/benchmark/gated_delta_rule_benchmark.py
@@ -1,0 +1,72 @@
+import os
+from contextlib import contextmanager
+
+import torch
+import triton
+
+from flag_attn.gated_delta_rule import chunk_gated_delta_rule_fwd
+
+
+FULL_TLE_ENV = "FLAG_ATTN_CHUNK_GATED_DELTA_RULE_TLE"
+RECOMPUTE_TLE_ENV = "FLAG_ATTN_CHUNK_GDR_RECOMPUTE_TLE"
+SHAPES = [
+    (2, 16384, 16, 128, 128),
+    (4, 2048, 16, 128, 128),
+    (4, 4096, 64, 128, 128),
+]
+
+
+@contextmanager
+def _set_tle(*, full_tle: bool, recompute_tle: bool):
+    old_full = os.environ.get(FULL_TLE_ENV)
+    old_recompute = os.environ.get(RECOMPUTE_TLE_ENV)
+    os.environ[FULL_TLE_ENV] = "1" if full_tle else "0"
+    os.environ[RECOMPUTE_TLE_ENV] = "1" if recompute_tle else "0"
+    try:
+        yield
+    finally:
+        if old_full is None:
+            os.environ.pop(FULL_TLE_ENV, None)
+        else:
+            os.environ[FULL_TLE_ENV] = old_full
+        if old_recompute is None:
+            os.environ.pop(RECOMPUTE_TLE_ENV, None)
+        else:
+            os.environ[RECOMPUTE_TLE_ENV] = old_recompute
+
+
+def _make_inputs(shape: tuple[int, int, int, int, int], dtype: torch.dtype):
+    B, T, H, K, V = shape
+    device = torch.device("cuda")
+    q = torch.randn(B, T, H, K, device=device, dtype=dtype) / (K**0.5)
+    k = torch.randn(B, T, H, K, device=device, dtype=dtype) / (K**0.5)
+    v = torch.randn(B, T, H, V, device=device, dtype=dtype)
+    g = (-torch.rand(B, T, H, device=device, dtype=torch.float32) * 0.1).to(dtype)
+    beta = torch.rand(B, T, H, device=device, dtype=dtype).sigmoid()
+    return q, k, v, g, beta, K**-0.5, None, True, None
+
+
+@torch.inference_mode()
+def benchmark() -> None:
+    print("dtype,shape,baseline_ms,optimized_ms,speedup")
+    for dtype in (torch.float16, torch.bfloat16):
+        for shape in SHAPES:
+            torch.manual_seed(42)
+            args = _make_inputs(shape, dtype)
+            with _set_tle(full_tle=False, recompute_tle=False):
+                baseline_ms = triton.testing.do_bench(
+                    lambda: chunk_gated_delta_rule_fwd(*args), warmup=25, rep=100
+                )
+            with _set_tle(full_tle=True, recompute_tle=True):
+                optimized_ms = triton.testing.do_bench(
+                    lambda: chunk_gated_delta_rule_fwd(*args), warmup=25, rep=100
+                )
+            shape_name = f"B{shape[0]}_T{shape[1]}_H{shape[2]}_K{shape[3]}_V{shape[4]}"
+            print(
+                f"{dtype},{shape_name},{baseline_ms:.6f},{optimized_ms:.6f},"
+                f"{baseline_ms / optimized_ms:.3f}x"
+            )
+
+
+if __name__ == "__main__":
+    benchmark()

--- a/benchmark/gated_delta_rule_benchmark.py
+++ b/benchmark/gated_delta_rule_benchmark.py
@@ -9,6 +9,7 @@ from flag_attn.gated_delta_rule import chunk_gated_delta_rule_fwd
 
 FULL_TLE_ENV = "FLAG_ATTN_CHUNK_GATED_DELTA_RULE_TLE"
 RECOMPUTE_TLE_ENV = "FLAG_ATTN_CHUNK_GDR_RECOMPUTE_TLE"
+TWO_KERNEL_TLE_ENV = "FLAG_ATTN_CHUNK_GDR_TWO_KERNEL_TLE"
 SHAPES = [
     (2, 16384, 16, 128, 128),
     (4, 2048, 16, 128, 128),
@@ -17,11 +18,13 @@ SHAPES = [
 
 
 @contextmanager
-def _set_tle(*, full_tle: bool, recompute_tle: bool):
+def _set_tle(*, full_tle: bool, recompute_tle: bool, two_kernel_tle: bool):
     old_full = os.environ.get(FULL_TLE_ENV)
     old_recompute = os.environ.get(RECOMPUTE_TLE_ENV)
+    old_two_kernel = os.environ.get(TWO_KERNEL_TLE_ENV)
     os.environ[FULL_TLE_ENV] = "1" if full_tle else "0"
     os.environ[RECOMPUTE_TLE_ENV] = "1" if recompute_tle else "0"
+    os.environ[TWO_KERNEL_TLE_ENV] = "1" if two_kernel_tle else "0"
     try:
         yield
     finally:
@@ -33,6 +36,10 @@ def _set_tle(*, full_tle: bool, recompute_tle: bool):
             os.environ.pop(RECOMPUTE_TLE_ENV, None)
         else:
             os.environ[RECOMPUTE_TLE_ENV] = old_recompute
+        if old_two_kernel is None:
+            os.environ.pop(TWO_KERNEL_TLE_ENV, None)
+        else:
+            os.environ[TWO_KERNEL_TLE_ENV] = old_two_kernel
 
 
 def _make_inputs(shape: tuple[int, int, int, int, int], dtype: torch.dtype):
@@ -53,11 +60,19 @@ def benchmark() -> None:
         for shape in SHAPES:
             torch.manual_seed(42)
             args = _make_inputs(shape, dtype)
-            with _set_tle(full_tle=False, recompute_tle=False):
+            with _set_tle(
+                full_tle=False,
+                recompute_tle=False,
+                two_kernel_tle=False,
+            ):
                 baseline_ms = triton.testing.do_bench(
                     lambda: chunk_gated_delta_rule_fwd(*args), warmup=25, rep=100
                 )
-            with _set_tle(full_tle=True, recompute_tle=True):
+            with _set_tle(
+                full_tle=False,
+                recompute_tle=False,
+                two_kernel_tle=True,
+            ):
                 optimized_ms = triton.testing.do_bench(
                     lambda: chunk_gated_delta_rule_fwd(*args), warmup=25, rep=100
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ version_file = "src/flag_attn/_version.py"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["flag_attn"]
+include = ["flag_attn", "flag_attn.*"]
 namespaces = false
 
 # helps for setting up pytest in pyprojects

--- a/src/flag_attn/__init__.py
+++ b/src/flag_attn/__init__.py
@@ -10,5 +10,6 @@ from flag_attn.piecewise import attention as piecewise_attention # noqa: F401
 from flag_attn.flash import attention as flash_attention # noqa: F401
 from flag_attn.split_kv import attention as flash_attention_split_kv # noqa: F401
 from flag_attn.paged import attention as paged_attention # noqa: F401
+from flag_attn.gated_delta_rule import chunk_gated_delta_rule # noqa: F401
 
 from flag_attn import testing # noqa: F401

--- a/src/flag_attn/dropout.py
+++ b/src/flag_attn/dropout.py
@@ -1,6 +1,4 @@
 import torch
-import triton
-import triton.language as tl
 
 def philox_cuda_seed_offset(increment, device=None):
     device = device or torch.cuda.current_device()

--- a/src/flag_attn/gated_delta_rule/__init__.py
+++ b/src/flag_attn/gated_delta_rule/__init__.py
@@ -1,0 +1,4 @@
+from .api import chunk_gated_delta_rule
+from .chunk import chunk_gated_delta_rule_fwd
+
+__all__ = ["chunk_gated_delta_rule", "chunk_gated_delta_rule_fwd"]

--- a/src/flag_attn/gated_delta_rule/api.py
+++ b/src/flag_attn/gated_delta_rule/api.py
@@ -1,0 +1,1095 @@
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from .chunk import chunk_gated_delta_rule_fwd
+from .chunk_gated_delta_direct import (
+    can_use_chunk_gated_delta_rule_direct,
+    chunk_gated_delta_rule_direct_fwd,
+)
+from .compat import has_triton_tle, libentry
+from .fused_cumsum_kkt_solve_tril import (
+    chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril,
+)
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE_CHUNK_GATED_DELTA_RULE = True
+    except ImportError:
+        tle = None
+        HAS_TLE_CHUNK_GATED_DELTA_RULE = False
+else:
+    tle = None
+    HAS_TLE_CHUNK_GATED_DELTA_RULE = False
+
+
+TLE_CHUNK_GDR_BLOCK_S = 64
+TLE_CHUNK_GDR_HEAD_DIM = 128
+TLE_CHUNK_GDR_PIPE_CAPACITY = 2
+TLE_CHUNK_GDR_TARGET_NUM_CTAS = 128
+
+
+@libentry()
+@triton.jit
+def _l2_normalize_last_dim_kernel(
+    x,
+    out,
+    n_rows: tl.constexpr,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    stride_x_b: tl.constexpr,
+    stride_x_t: tl.constexpr,
+    stride_x_h: tl.constexpr,
+    stride_x_k: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offs = tl.arange(0, BLOCK_K)
+    mask = offs < K
+
+    h = row % H
+    row_bt = row // H
+    t = row_bt % n_rows
+    b = row_bt // n_rows
+    x_base = x + b * stride_x_b + t * stride_x_t + h * stride_x_h
+    values = tl.load(x_base + offs * stride_x_k, mask=mask, other=0.0).to(tl.float32)
+    inv_norm = 1.0 / tl.maximum(tl.sqrt(tl.sum(values * values, axis=0)), 1e-6)
+    tl.store(out + row * K + offs, values * inv_norm, mask=mask)
+
+
+def _tle_chunk_gdr_enabled() -> bool:
+    value = os.environ.get("FLAG_ATTN_CHUNK_GATED_DELTA_RULE_TLE", "1").lower()
+    return value not in {"0", "false", "off", "no"}
+
+
+def _tle_chunk_gdr_target_num_ctas(device: torch.device) -> int:
+    try:
+        props = torch.cuda.get_device_properties(device)
+        return max(1, int(props.multi_processor_count * 0.7))
+    except Exception:
+        return TLE_CHUNK_GDR_TARGET_NUM_CTAS
+
+
+def _tle_chunk_gdr_block_dv(
+    batch_size: int, num_value_heads: int, target_num_ctas: int
+) -> int:
+    grid_size = batch_size * num_value_heads
+    if grid_size >= target_num_ctas:
+        return 128
+    if grid_size * 2 >= target_num_ctas:
+        return 64
+    return 32
+
+
+def _resolve_tle_chunk_gdr_block_dv(
+    batch_size: int,
+    num_value_heads: int,
+    value_dim: int,
+    device: torch.device,
+) -> int:
+    target_num_ctas = _tle_chunk_gdr_target_num_ctas(device)
+    block_dv = _tle_chunk_gdr_block_dv(batch_size, num_value_heads, target_num_ctas)
+    if value_dim % block_dv != 0:
+        return value_dim
+    return block_dv
+
+
+def _set_tle_descriptor_allocator(device: torch.device) -> None:
+    def alloc_fn(size: int, align: int, stream):
+        _ = align
+        _ = stream
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+
+
+def _can_use_tle_chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None,
+) -> bool:
+    if not (HAS_TLE_CHUNK_GATED_DELTA_RULE and _tle_chunk_gdr_enabled()):
+        return False
+    if not output_final_state:
+        return False
+    if initial_state is not None or cu_seqlens is not None:
+        return False
+    if q.device.type != "cuda":
+        return False
+    if not all(x.device == q.device for x in (k, v, beta, g)):
+        return False
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        return False
+    if not all(x.dtype == q.dtype for x in (k, v, beta, g)):
+        return False
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        return False
+    if beta.ndim != 3 or g.ndim != 3:
+        return False
+
+    B, T, Hg, K = q.shape
+    H = v.shape[2]
+    return (
+        k.shape == (B, T, Hg, K)
+        and v.shape[:2] == (B, T)
+        and beta.shape == (B, T, H)
+        and g.shape == (B, T, H)
+        and H % Hg == 0
+        and K == TLE_CHUNK_GDR_HEAD_DIM
+        and v.shape[3] == TLE_CHUNK_GDR_HEAD_DIM
+        and T > 0
+        and T % TLE_CHUNK_GDR_BLOCK_S == 0
+    )
+
+
+if HAS_TLE_CHUNK_GATED_DELTA_RULE:
+
+    @triton.jit
+    def _tle_chunk_gdr_linear_pids(
+        H: tl.constexpr,
+        DV: tl.constexpr,
+        BLOCK_DV: tl.constexpr,
+    ):
+        bbhv = tl.program_id(0)
+        num_v_blocks: tl.constexpr = tl.cdiv(DV, BLOCK_DV)
+        bbh = bbhv // num_v_blocks
+        pid_v = bbhv - bbh * num_v_blocks
+        pid_b = bbh // H
+        pid_h = bbh - pid_b * H
+        return pid_v, pid_b, pid_h
+
+    @triton.jit
+    def _tle_chunk_gdr_qk_producer(
+        qk_writer,
+        q_desc,
+        k_desc,
+        pid_b,
+        pid_hg,
+        T: tl.constexpr,
+        DK: tl.constexpr,
+        CHUNK: tl.constexpr,
+    ):
+        num_chunks: tl.constexpr = tl.cdiv(T, CHUNK)
+
+        for chunk in tl.range(num_chunks):
+            qk_slot = qk_writer.acquire(chunk)
+            left = chunk * CHUNK
+            tle.gpu.copy(
+                q_desc,
+                qk_slot.q,
+                [1, 1, CHUNK, DK],
+                [pid_b, pid_hg, left, 0],
+            )
+            tle.gpu.copy(
+                k_desc,
+                qk_slot.k,
+                [1, 1, CHUNK, DK],
+                [pid_b, pid_hg, left, 0],
+            )
+            qk_writer.commit(chunk)
+
+    @triton.jit
+    def _tle_chunk_gdr_vbeta_producer(
+        vbeta_writer,
+        v_desc,
+        beta,
+        pid_b,
+        pid_h,
+        block_v,
+        T: tl.constexpr,
+        H: tl.constexpr,
+        CHUNK: tl.constexpr,
+        BLOCK_DV: tl.constexpr,
+    ):
+        offs_s = tl.arange(0, CHUNK)
+        num_chunks: tl.constexpr = tl.cdiv(T, CHUNK)
+        gh_batch_base: tl.constexpr = T * H
+
+        for chunk in tl.range(num_chunks):
+            vbeta_slot = vbeta_writer.acquire(chunk)
+            left = chunk * CHUNK
+            token = left + offs_s
+            tle.gpu.copy(
+                v_desc,
+                vbeta_slot.v,
+                [1, 1, CHUNK, BLOCK_DV],
+                [pid_b, pid_h, left, block_v],
+            )
+            beta_ptrs = beta + pid_b * gh_batch_base + token * H + pid_h
+            beta_blk = tl.load(beta_ptrs)
+            tl.store(tle.gpu.local_ptr(vbeta_slot.beta), beta_blk)
+            vbeta_writer.commit(chunk)
+
+    @triton.jit
+    def _tle_chunk_gdr_ag_producer(
+        agamma_writer,
+        a_desc,
+        g,
+        pid_b,
+        pid_h,
+        T: tl.constexpr,
+        H: tl.constexpr,
+        CHUNK: tl.constexpr,
+    ):
+        offs_s = tl.arange(0, CHUNK)
+        num_chunks: tl.constexpr = tl.cdiv(T, CHUNK)
+        gh_batch_base: tl.constexpr = T * H
+
+        for chunk in tl.range(num_chunks):
+            agamma_slot = agamma_writer.acquire(chunk)
+            left = chunk * CHUNK
+            token = left + offs_s
+            tle.gpu.copy(
+                a_desc,
+                agamma_slot.a,
+                [1, 1, CHUNK, CHUNK],
+                [pid_b, pid_h, left, 0],
+            )
+            g_ptrs = g + pid_b * gh_batch_base + token * H + pid_h
+            g_blk = tl.load(g_ptrs)
+            tl.store(tle.gpu.local_ptr(agamma_slot.g), g_blk)
+            agamma_writer.commit(chunk)
+
+    @triton.jit
+    def _tle_chunk_gdr_state_worker(
+        data_reader,
+        h_writer,
+        gate_reader,
+        vn_reader,
+        final_state,
+        pid_b,
+        pid_h,
+        block_v,
+        T: tl.constexpr,
+        H: tl.constexpr,
+        DK: tl.constexpr,
+        DV: tl.constexpr,
+        CHUNK: tl.constexpr,
+        BLOCK_DV: tl.constexpr,
+    ):
+        offs_k = tl.arange(0, DK)
+        offs_v = tl.arange(0, BLOCK_DV)
+        num_chunks: tl.constexpr = tl.cdiv(T, CHUNK)
+        h_batch_base: tl.constexpr = H * DK * DV
+        h_state = tl.zeros((DK, BLOCK_DV), dtype=tl.float32)
+        for chunk in tl.range(num_chunks):
+            h_slot = h_writer.acquire(chunk)
+            tl.store(tle.gpu.local_ptr(h_slot.h), h_state.to(h_slot.h.dtype))
+            h_writer.commit(chunk)
+
+            gate_wait = gate_reader.wait(chunk)
+            gate_slot = gate_wait.slot
+            g_last = tl.load(tle.gpu.local_ptr(gate_slot.g_exp, (CHUNK - 1,))).to(
+                tl.float32
+            )
+            h_state *= g_last
+            gate_reader.release(chunk)
+
+            data_wait = data_reader.wait(chunk)
+            data_slot = data_wait.slot
+            vn_wait = vn_reader.wait(chunk)
+            vn_slot = vn_wait.slot
+            k_blk = tl.load(tle.gpu.local_ptr(data_slot.k))
+            vn_blk = tl.load(tle.gpu.local_ptr(vn_slot.vn))
+            h_state += tl.dot(tl.trans(k_blk), vn_blk, out_dtype=tl.float32)
+            vn_reader.release(chunk)
+            data_reader.release(chunk)
+
+        h_ptrs = (
+            final_state
+            + pid_b * h_batch_base
+            + pid_h * (DK * DV)
+            + offs_k[:, None] * DV
+            + block_v
+            + offs_v[None, :]
+        )
+        tl.store(h_ptrs, h_state)
+
+    @triton.jit
+    def _tle_chunk_gdr_value_worker(
+        qk_reader,
+        vbeta_reader,
+        agamma_reader,
+        h_reader,
+        gate_writer,
+        computed_ag_reader,
+        vd_writer,
+        vn_writer,
+        T: tl.constexpr,
+        DK: tl.constexpr,
+        CHUNK: tl.constexpr,
+    ):
+        num_chunks: tl.constexpr = tl.cdiv(T, CHUNK)
+        for chunk in tl.range(num_chunks):
+            agamma_wait = agamma_reader.wait(chunk)
+            agamma_slot = agamma_wait.slot
+
+            g_vec = tl.load(tle.gpu.local_ptr(agamma_slot.g)).to(tl.float32)
+            g_exp = tl.math.exp2(g_vec * 1.4426950408889634)
+            g_last = tl.load(tle.gpu.local_ptr(agamma_slot.g, (CHUNK - 1,))).to(
+                tl.float32
+            )
+            g_rev_exp = tl.math.exp2((g_last - g_vec) * 1.4426950408889634)
+
+            gate_slot = gate_writer.acquire(chunk)
+            tl.store(tle.gpu.local_ptr(gate_slot.g_exp), g_exp)
+            tl.store(tle.gpu.local_ptr(gate_slot.g_rev), g_rev_exp)
+            gate_writer.commit(chunk)
+
+            h_wait = h_reader.wait(chunk)
+            h_slot = h_wait.slot
+            qk_wait = qk_reader.wait(chunk)
+            qk_slot = qk_wait.slot
+            vbeta_wait = vbeta_reader.wait(chunk)
+            vbeta_slot = vbeta_wait.slot
+            k_blk = tl.load(tle.gpu.local_ptr(qk_slot.k))
+            h_blk = tl.load(tle.gpu.local_ptr(h_slot.h))
+            v_blk = tl.load(tle.gpu.local_ptr(vbeta_slot.v))
+            u = tl.dot(k_blk, h_blk, out_dtype=tl.float32)
+            h_reader.release(chunk)
+
+            w = v_blk.to(tl.float32) - g_exp[:, None] * u
+            tl.store(tle.gpu.local_ptr(vbeta_slot.v), w.to(v_blk.dtype))
+
+            ag_wait = computed_ag_reader.wait(chunk)
+            ag_slot = ag_wait.slot
+            ag_blk = tl.load(tle.gpu.local_ptr(ag_slot.ag))
+            w_blk = tl.load(tle.gpu.local_ptr(vbeta_slot.v))
+            vd = tl.dot(ag_blk, w_blk, out_dtype=tl.float32)
+            vn = g_rev_exp[:, None] * vd
+            qk_reader.release(chunk)
+            vbeta_reader.release(chunk)
+            agamma_reader.release(chunk)
+            computed_ag_reader.release(chunk)
+
+            vd_slot = vd_writer.acquire(chunk)
+            tl.store(tle.gpu.local_ptr(vd_slot.vd), vd.to(ag_blk.dtype))
+            vd_writer.commit(chunk)
+
+            vn_slot = vn_writer.acquire(chunk)
+            tl.store(tle.gpu.local_ptr(vn_slot.vn), vn.to(ag_blk.dtype))
+            vn_writer.commit(chunk)
+
+    @triton.jit
+    def _tle_chunk_gdr_output_worker(
+        qk_reader,
+        vbeta_reader,
+        agamma_reader,
+        h_reader,
+        gate_reader,
+        ag_writer,
+        vd_reader,
+        p_smem,
+        o_writer,
+        T: tl.constexpr,
+        DK: tl.constexpr,
+        CHUNK: tl.constexpr,
+        scale: tl.constexpr,
+    ):
+        rows = tl.arange(0, CHUNK)[:, None]
+        cols = tl.arange(0, CHUNK)[None, :]
+        num_chunks: tl.constexpr = tl.cdiv(T, CHUNK)
+        for chunk in tl.range(num_chunks):
+            qk_wait = qk_reader.wait(chunk)
+            qk_slot = qk_wait.slot
+            q_blk = tl.load(tle.gpu.local_ptr(qk_slot.q))
+            k_blk = tl.load(tle.gpu.local_ptr(qk_slot.k))
+            p = tl.dot(q_blk, tl.trans(k_blk), out_dtype=tl.float32)
+
+            vbeta_wait = vbeta_reader.wait(chunk)
+            vbeta_slot = vbeta_wait.slot
+            agamma_wait = agamma_reader.wait(chunk)
+            agamma_slot = agamma_wait.slot
+            a_blk = tl.load(tle.gpu.local_ptr(agamma_slot.a)).to(tl.float32)
+            beta_vec = tl.load(tle.gpu.local_ptr(vbeta_slot.beta)).to(tl.float32)
+            g_vec = tl.load(tle.gpu.local_ptr(agamma_slot.g)).to(tl.float32)
+            lower = rows >= cols
+            g_mat = tl.where(
+                lower,
+                tl.math.exp2((g_vec[:, None] - g_vec[None, :]) * 1.4426950408889634),
+                0.0,
+            )
+            ag = a_blk * g_mat * beta_vec[None, :]
+            ag_slot = ag_writer.acquire(chunk)
+            tl.store(tle.gpu.local_ptr(ag_slot.ag), ag.to(q_blk.dtype))
+            ag_writer.commit(chunk)
+            qk_reader.release(chunk)
+            vbeta_reader.release(chunk)
+            agamma_reader.release(chunk)
+
+            h_wait = h_reader.wait(chunk)
+            h_slot = h_wait.slot
+            gate_wait = gate_reader.wait(chunk)
+            gate_slot = gate_wait.slot
+            h_blk = tl.load(tle.gpu.local_ptr(h_slot.h))
+            g_exp = tl.load(tle.gpu.local_ptr(gate_slot.g_exp)).to(tl.float32)
+            o_blk = tl.dot(q_blk, h_blk, out_dtype=tl.float32)
+            h_reader.release(chunk)
+
+            pg = p * (scale * g_mat)
+            tl.store(tle.gpu.local_ptr(p_smem), pg.to(q_blk.dtype))
+            p_blk = tl.load(tle.gpu.local_ptr(p_smem))
+            o_blk *= scale * g_exp[:, None]
+            gate_reader.release(chunk)
+
+            vd_wait = vd_reader.wait(chunk)
+            vd_slot = vd_wait.slot
+            vd_blk = tl.load(tle.gpu.local_ptr(vd_slot.vd))
+            o_blk += tl.dot(p_blk, vd_blk, out_dtype=tl.float32)
+            vd_reader.release(chunk)
+
+            o_slot = o_writer.acquire(chunk)
+            tl.store(tle.gpu.local_ptr(o_slot.o), o_blk.to(q_blk.dtype))
+            o_writer.commit(chunk)
+
+    @triton.jit
+    def _tle_chunk_gdr_store_worker(
+        o_reader,
+        o_desc,
+        pid_b,
+        pid_h,
+        block_v,
+        T: tl.constexpr,
+        DV: tl.constexpr,
+        CHUNK: tl.constexpr,
+        BLOCK_DV: tl.constexpr,
+    ):
+        num_chunks: tl.constexpr = tl.cdiv(T, CHUNK)
+
+        for chunk in tl.range(1, num_chunks):
+            store_chunk = chunk - 1
+            wait = o_reader.wait(store_chunk)
+            slot = wait.slot
+            left = store_chunk * CHUNK
+            tle.gpu.copy(
+                slot.o,
+                o_desc,
+                [1, 1, CHUNK, BLOCK_DV],
+                [pid_b, pid_h, left, block_v],
+            )
+            o_reader.release(store_chunk)
+
+        last_chunk: tl.constexpr = ((T + CHUNK - 1) // CHUNK) - 1
+        wait = o_reader.wait(last_chunk)
+        slot = wait.slot
+        left = last_chunk * CHUNK
+        tle.gpu.copy(
+            slot.o,
+            o_desc,
+            [1, 1, CHUNK, BLOCK_DV],
+            [pid_b, pid_h, left, block_v],
+        )
+        o_reader.release(last_chunk)
+
+    @triton.jit
+    def _tle_chunk_gdr_fwd_kernel(
+        q_desc,
+        k_desc,
+        v_desc,
+        a_desc,
+        g,
+        beta,
+        o_desc,
+        final_state,
+        T: tl.constexpr,
+        H: tl.constexpr,
+        HG: tl.constexpr,
+        DK: tl.constexpr,
+        DV: tl.constexpr,
+        CHUNK: tl.constexpr,
+        BLOCK_DV: tl.constexpr,
+        PIPE_CAPACITY: tl.constexpr,
+        scale: tl.constexpr,
+    ):
+        pid_v, pid_b, pid_h = _tle_chunk_gdr_linear_pids(H, DV, BLOCK_DV)
+        block_v = pid_v * BLOCK_DV
+        if H != HG:
+            pid_hg = pid_h // (H // HG)
+        else:
+            pid_hg = pid_h
+
+        q_smem = tle.gpu.alloc(
+            [PIPE_CAPACITY, CHUNK, DK],
+            dtype=q_desc.dtype,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        k_smem = tle.gpu.alloc(
+            [PIPE_CAPACITY, CHUNK, DK],
+            dtype=k_desc.dtype,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        v_smem = tle.gpu.alloc(
+            [PIPE_CAPACITY, CHUNK, BLOCK_DV],
+            dtype=v_desc.dtype,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        a_smem = tle.gpu.alloc(
+            [PIPE_CAPACITY, CHUNK, CHUNK],
+            dtype=a_desc.dtype,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        g_smem = tle.gpu.alloc(
+            [PIPE_CAPACITY, CHUNK],
+            dtype=g.dtype.element_ty,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        beta_smem = tle.gpu.alloc(
+            [PIPE_CAPACITY, CHUNK],
+            dtype=beta.dtype.element_ty,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        h_smem = tle.gpu.alloc(
+            [1, DK, BLOCK_DV],
+            dtype=q_desc.dtype,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        g_exp_smem = tle.gpu.alloc(
+            [1, CHUNK],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        g_rev_exp_smem = tle.gpu.alloc(
+            [1, CHUNK],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        vd_smem = tle.gpu.alloc(
+            [1, CHUNK, BLOCK_DV],
+            dtype=q_desc.dtype,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        vn_smem = tle.gpu.alloc(
+            [1, CHUNK, BLOCK_DV],
+            dtype=q_desc.dtype,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        p_smem = tle.gpu.alloc(
+            [CHUNK, CHUNK],
+            dtype=q_desc.dtype,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        o_smem = tle.gpu.alloc(
+            [1, CHUNK, BLOCK_DV],
+            dtype=q_desc.dtype,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+
+        qk_pipe = tle.pipe(
+            capacity=PIPE_CAPACITY,
+            scope="cta",
+            name="gdr_qk",
+            readers=("state", "value", "output"),
+            q=q_smem,
+            k=k_smem,
+        )
+        vbeta_pipe = tle.pipe(
+            capacity=PIPE_CAPACITY,
+            scope="cta",
+            name="gdr_vbeta",
+            readers=("value", "output"),
+            v=v_smem,
+            beta=beta_smem,
+        )
+        agamma_pipe = tle.pipe(
+            capacity=PIPE_CAPACITY,
+            scope="cta",
+            name="gdr_agamma",
+            readers=("value", "output"),
+            a=a_smem,
+            g=g_smem,
+        )
+        h_pipe = tle.pipe(
+            capacity=1,
+            scope="cta",
+            name="gdr_h",
+            readers=("value", "output"),
+            h=h_smem,
+        )
+        gate_pipe = tle.pipe(
+            capacity=1,
+            scope="cta",
+            name="gdr_gate",
+            readers=("state", "output"),
+            g_exp=g_exp_smem,
+            g_rev=g_rev_exp_smem,
+        )
+        ag_pipe = tle.pipe(
+            capacity=PIPE_CAPACITY,
+            scope="cta",
+            name="gdr_ag",
+            ag=a_smem,
+        )
+        vd_pipe = tle.pipe(
+            capacity=1,
+            scope="cta",
+            name="gdr_vd",
+            readers=("output",),
+            vd=vd_smem,
+        )
+        vn_pipe = tle.pipe(
+            capacity=1,
+            scope="cta",
+            name="gdr_vn",
+            readers=("state",),
+            vn=vn_smem,
+        )
+        o_pipe = tle.pipe(
+            capacity=1,
+            scope="cta",
+            name="gdr_o",
+            readers=("store",),
+            o=o_smem,
+        )
+
+        tle.gpu.warp_specialize(
+            [
+                (
+                    _tle_chunk_gdr_state_worker,
+                    (
+                        qk_pipe.reader("state", fields=("k",)),
+                        h_pipe.writer(),
+                        gate_pipe.reader("state", fields=("g_exp",)),
+                        vn_pipe.reader("state"),
+                        final_state,
+                        pid_b,
+                        pid_h,
+                        block_v,
+                        T,
+                        H,
+                        DK,
+                        DV,
+                        CHUNK,
+                        BLOCK_DV,
+                    ),
+                ),
+                (
+                    _tle_chunk_gdr_value_worker,
+                    (
+                        qk_pipe.reader("value", fields=("k",)),
+                        vbeta_pipe.reader("value", fields=("v",)),
+                        agamma_pipe.reader("value", fields=("g",)),
+                        h_pipe.reader("value"),
+                        gate_pipe.writer(),
+                        ag_pipe.reader(),
+                        vd_pipe.writer(),
+                        vn_pipe.writer(),
+                        T,
+                        DK,
+                        CHUNK,
+                    ),
+                ),
+                (
+                    _tle_chunk_gdr_output_worker,
+                    (
+                        qk_pipe.reader("output", fields=("q", "k")),
+                        vbeta_pipe.reader("output", fields=("beta",)),
+                        agamma_pipe.reader("output", fields=("a", "g")),
+                        h_pipe.reader("output"),
+                        gate_pipe.reader("output", fields=("g_exp",)),
+                        ag_pipe.writer(),
+                        vd_pipe.reader("output"),
+                        p_smem,
+                        o_pipe.writer(),
+                        T,
+                        DK,
+                        CHUNK,
+                        scale,
+                    ),
+                ),
+                (
+                    _tle_chunk_gdr_qk_producer,
+                    (
+                        qk_pipe.writer(),
+                        q_desc,
+                        k_desc,
+                        pid_b,
+                        pid_hg,
+                        T,
+                        DK,
+                        CHUNK,
+                    ),
+                ),
+                (
+                    _tle_chunk_gdr_vbeta_producer,
+                    (
+                        vbeta_pipe.writer(),
+                        v_desc,
+                        beta,
+                        pid_b,
+                        pid_h,
+                        block_v,
+                        T,
+                        H,
+                        CHUNK,
+                        BLOCK_DV,
+                    ),
+                ),
+                (
+                    _tle_chunk_gdr_ag_producer,
+                    (
+                        agamma_pipe.writer(),
+                        a_desc,
+                        g,
+                        pid_b,
+                        pid_h,
+                        T,
+                        H,
+                        CHUNK,
+                    ),
+                ),
+                (
+                    _tle_chunk_gdr_store_worker,
+                    (
+                        o_pipe.reader("store"),
+                        o_desc,
+                        pid_b,
+                        pid_h,
+                        block_v,
+                        T,
+                        DV,
+                        CHUNK,
+                        BLOCK_DV,
+                    ),
+                ),
+            ],
+            [4, 4, 1, 1, 1, 1],
+            [128, 128, 32, 32, 32, 32],
+        )
+
+    def _tle_chunk_gated_delta_rule_fwd(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g_cumsum: torch.Tensor,
+        beta: torch.Tensor,
+        a: torch.Tensor,
+        *,
+        scale: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from triton.tools.tensor_descriptor import TensorDescriptor
+
+        B, T, Hg, K = q.shape
+        H, V = v.shape[2], v.shape[3]
+        block_dv = _resolve_tle_chunk_gdr_block_dv(B, H, V, q.device)
+
+        _set_tle_descriptor_allocator(q.device)
+        o = torch.empty_like(v)
+        final_state = torch.empty((B, H, K, V), device=v.device, dtype=torch.float32)
+
+        q_desc = TensorDescriptor(
+            q,
+            shape=[B, Hg, T, K],
+            strides=[T * Hg * K, K, Hg * K, 1],
+            block_shape=[1, 1, TLE_CHUNK_GDR_BLOCK_S, K],
+        )
+        k_desc = TensorDescriptor(
+            k,
+            shape=[B, Hg, T, K],
+            strides=[T * Hg * K, K, Hg * K, 1],
+            block_shape=[1, 1, TLE_CHUNK_GDR_BLOCK_S, K],
+        )
+        v_desc = TensorDescriptor(
+            v,
+            shape=[B, H, T, V],
+            strides=[T * H * V, V, H * V, 1],
+            block_shape=[1, 1, TLE_CHUNK_GDR_BLOCK_S, block_dv],
+        )
+        a_desc = TensorDescriptor(
+            a,
+            shape=[B, H, T, TLE_CHUNK_GDR_BLOCK_S],
+            strides=[
+                T * H * TLE_CHUNK_GDR_BLOCK_S,
+                TLE_CHUNK_GDR_BLOCK_S,
+                H * TLE_CHUNK_GDR_BLOCK_S,
+                1,
+            ],
+            block_shape=[1, 1, TLE_CHUNK_GDR_BLOCK_S, TLE_CHUNK_GDR_BLOCK_S],
+        )
+        o_desc = TensorDescriptor(
+            o,
+            shape=[B, H, T, V],
+            strides=[T * H * V, V, H * V, 1],
+            block_shape=[1, 1, TLE_CHUNK_GDR_BLOCK_S, block_dv],
+        )
+
+        grid = (triton.cdiv(V, block_dv) * B * H,)
+        _tle_chunk_gdr_fwd_kernel[grid](
+            q_desc,
+            k_desc,
+            v_desc,
+            a_desc,
+            g_cumsum,
+            beta,
+            o_desc,
+            final_state,
+            T,
+            H,
+            Hg,
+            K,
+            V,
+            TLE_CHUNK_GDR_BLOCK_S,
+            block_dv,
+            TLE_CHUNK_GDR_PIPE_CAPACITY,
+            scale,
+            num_warps=4,
+        )
+        return o, final_state
+
+
+def _as_seq_first(
+    x: torch.Tensor,
+    *,
+    name: str,
+    head_first: bool,
+    expected_ndim: int,
+) -> torch.Tensor:
+    if not isinstance(x, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor")
+    if x.ndim != expected_ndim:
+        raise ValueError(f"{name} must be {expected_ndim}D, got shape {tuple(x.shape)}")
+    if head_first:
+        return x.transpose(1, 2)
+    return x
+
+
+def _validate_inputs(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+) -> None:
+    B, T, Hg, K = q.shape
+    Bk, Tk, Hk, Kk = k.shape
+    Bv, Tv, H, V = v.shape
+
+    tensors = {"k": k, "v": v, "beta": beta, "g": g}
+    for name, tensor in tensors.items():
+        if tensor.device != q.device:
+            raise ValueError(f"{name} must be on the same device as q")
+        if tensor.dtype != q.dtype:
+            raise ValueError(f"{name} must have the same dtype as q")
+
+    if (Bk, Tk, Hk, Kk) != (B, T, Hg, K):
+        raise ValueError(
+            "q and k must have matching [B, T, Hq, K] shapes after layout conversion"
+        )
+    if (Bv, Tv) != (B, T):
+        raise ValueError("v must have matching B and T dimensions with q/k")
+    if H % Hg != 0:
+        raise ValueError("the q/k head count must divide the v head count")
+    if beta.shape != (B, T, H):
+        raise ValueError(
+            f"beta must have shape {(B, T, H)} after layout conversion, got {tuple(beta.shape)}"
+        )
+    if g.shape != (B, T, H):
+        raise ValueError(
+            f"g must have shape {(B, T, H)} after layout conversion, got {tuple(g.shape)}"
+        )
+    if cu_seqlens is not None:
+        if not isinstance(cu_seqlens, torch.Tensor):
+            raise TypeError("cu_seqlens must be a torch.Tensor")
+        if cu_seqlens.ndim != 1:
+            raise ValueError("cu_seqlens must be a 1D tensor")
+        if cu_seqlens.dtype != torch.long:
+            raise ValueError("cu_seqlens must have dtype torch.long")
+        if cu_seqlens.device != q.device:
+            raise ValueError("cu_seqlens must be on the same device as q")
+        if B != 1:
+            raise ValueError("cu_seqlens packed varlen inputs must use B=1")
+
+    if initial_state is not None:
+        if initial_state.device != q.device:
+            raise ValueError("initial_state must be on the same device as q")
+        if initial_state.dtype != q.dtype:
+            raise ValueError("initial_state must have the same dtype as q")
+        expected_n = B if cu_seqlens is None else cu_seqlens.numel() - 1
+        expected_shape = (expected_n, H, K, V)
+        if initial_state.shape != expected_shape:
+            raise ValueError(
+                f"initial_state must have shape {expected_shape}, got {tuple(initial_state.shape)}"
+            )
+
+
+def _direct_contiguous(x: torch.Tensor) -> torch.Tensor:
+    return x if x.is_contiguous() else x.contiguous()
+
+
+def _l2_normalize_last_dim(x: torch.Tensor) -> torch.Tensor:
+    B, T, H, K = x.shape
+    out = torch.empty_like(x, memory_format=torch.contiguous_format)
+    block_k = triton.next_power_of_2(K)
+    _l2_normalize_last_dim_kernel[(B * T * H,)](
+        x=x,
+        out=out,
+        n_rows=T,
+        H=H,
+        K=K,
+        stride_x_b=x.stride(0),
+        stride_x_t=x.stride(1),
+        stride_x_h=x.stride(2),
+        stride_x_k=x.stride(3),
+        BLOCK_K=block_k,
+    )
+    return out
+
+
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    BT: int = 64,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    head_first: bool = True,
+    scale: float | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Public wrapper for the chunk gated delta rule forward operator.
+
+    Inputs follow common FLA layouts:
+    - ``head_first=True``: q/k/v are ``[B, H, T, D]`` and beta/g are ``[B, H, T]``.
+    - ``head_first=False``: q/k/v are ``[B, T, H, D]`` and beta/g are ``[B, T, H]``.
+
+    q/k may use fewer heads than v when the q/k head count divides the v head count.
+    """
+    if BT != 64:
+        raise ValueError("chunk_gated_delta_rule currently supports only BT=64")
+
+    q_seq = _as_seq_first(q, name="q", head_first=head_first, expected_ndim=4)
+    k_seq = _as_seq_first(k, name="k", head_first=head_first, expected_ndim=4)
+    v_seq = _as_seq_first(v, name="v", head_first=head_first, expected_ndim=4)
+    beta_seq = _as_seq_first(beta, name="beta", head_first=head_first, expected_ndim=3)
+    g_seq = _as_seq_first(g, name="g", head_first=head_first, expected_ndim=3)
+
+    _validate_inputs(q_seq, k_seq, v_seq, beta_seq, g_seq, initial_state, cu_seqlens)
+
+    if scale is None:
+        scale = k_seq.shape[-1] ** -0.5
+
+    B, T, Hg, K = q_seq.shape
+    H, V = v_seq.shape[2], v_seq.shape[3]
+    if (
+        initial_state is None
+        and cu_seqlens is None
+        and T <= 128
+        and K <= 128
+        and V <= 128
+        and H % Hg == 0
+    ):
+        q_direct = _direct_contiguous(q_seq)
+        k_direct = _direct_contiguous(k_seq)
+        v_direct = _direct_contiguous(v_seq)
+        g_direct = _direct_contiguous(g_seq)
+        beta_direct = _direct_contiguous(beta_seq)
+        if can_use_chunk_gated_delta_rule_direct(
+            q=q_direct,
+            k=k_direct,
+            v=v_direct,
+            g=g_direct,
+            beta=beta_direct,
+            initial_state=None,
+            cu_seqlens=None,
+        ):
+            o, final_state = chunk_gated_delta_rule_direct_fwd(
+                q=q_direct,
+                k=k_direct,
+                v=v_direct,
+                g=g_direct,
+                beta=beta_direct,
+                scale=float(scale),
+                initial_state=None,
+                output_final_state=output_final_state,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            )
+            if head_first:
+                o = o.transpose(1, 2)
+            return o, final_state
+
+    if use_qk_l2norm_in_kernel:
+        q_seq = _l2_normalize_last_dim(q_seq)
+        k_seq = _l2_normalize_last_dim(k_seq)
+
+    if _can_use_tle_chunk_gated_delta_rule(
+        q_seq,
+        k_seq,
+        v_seq,
+        beta_seq,
+        g_seq,
+        initial_state,
+        output_final_state,
+        cu_seqlens,
+    ):
+        q_tle = _direct_contiguous(q_seq)
+        k_tle = _direct_contiguous(k_seq)
+        v_tle = _direct_contiguous(v_seq)
+        beta_tle = _direct_contiguous(beta_seq)
+        g_tle = _direct_contiguous(g_seq)
+        g_cumsum, a = chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
+            g=g_tle,
+            k=k_tle,
+            beta=beta_tle,
+            cu_seqlens=None,
+            chunk_size=TLE_CHUNK_GDR_BLOCK_S,
+            output_dtype=k_tle.dtype,
+            use_g_in_kkt=False,
+        )
+        o, final_state = _tle_chunk_gated_delta_rule_fwd(
+            q=q_tle,
+            k=k_tle,
+            v=v_tle,
+            g_cumsum=g_cumsum,
+            beta=beta_tle,
+            a=a,
+            scale=float(scale),
+        )
+        if head_first:
+            o = o.transpose(1, 2)
+        return o, final_state if output_final_state else None
+
+    _, o, _, final_state, _, _, _ = chunk_gated_delta_rule_fwd(
+        q=q_seq,
+        k=k_seq,
+        v=v_seq,
+        g=g_seq,
+        beta=beta_seq,
+        scale=float(scale),
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+    )
+
+    if head_first:
+        o = o.transpose(1, 2)
+    return o, final_state

--- a/src/flag_attn/gated_delta_rule/api.py
+++ b/src/flag_attn/gated_delta_rule/api.py
@@ -9,6 +9,7 @@ from .chunk_gated_delta_direct import (
     can_use_chunk_gated_delta_rule_direct,
     chunk_gated_delta_rule_direct_fwd,
 )
+from .chunk_fused_forward import can_use_two_kernel_fused_forward
 from .compat import has_triton_tle, libentry
 from .fused_cumsum_kkt_solve_tril import (
     chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril,
@@ -1043,7 +1044,17 @@ def chunk_gated_delta_rule(
         q_seq = _l2_normalize_last_dim(q_seq)
         k_seq = _l2_normalize_last_dim(k_seq)
 
-    if _can_use_tle_chunk_gated_delta_rule(
+    use_two_kernel_fused_forward = can_use_two_kernel_fused_forward(
+        q=q_seq,
+        k=k_seq,
+        v=v_seq,
+        beta=beta_seq,
+        g=g_seq,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+    )
+    if not use_two_kernel_fused_forward and _can_use_tle_chunk_gated_delta_rule(
         q_seq,
         k_seq,
         v_seq,

--- a/src/flag_attn/gated_delta_rule/api.py
+++ b/src/flag_attn/gated_delta_rule/api.py
@@ -146,7 +146,9 @@ def _can_use_tle_chunk_gated_delta_rule(
         and H % Hg == 0
         and K == TLE_CHUNK_GDR_HEAD_DIM
         and v.shape[3] == TLE_CHUNK_GDR_HEAD_DIM
-        and T > 0
+        # Keep low-workload shapes on the numerically stable native path.
+        and B * H >= 32
+        and T >= 2048
         and T % TLE_CHUNK_GDR_BLOCK_S == 0
     )
 

--- a/src/flag_attn/gated_delta_rule/chunk.py
+++ b/src/flag_attn/gated_delta_rule/chunk.py
@@ -1,0 +1,192 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+
+import logging
+
+import torch
+
+from .chunk_delta_h import chunk_gated_delta_rule_fwd_h
+from .chunk_fused_tail_vblock import (
+    can_use_fused_tail_vblock,
+    chunk_gated_delta_rule_fused_tail_vblock,
+)
+from .chunk_o import chunk_fwd_o
+from .fused_cumsum_kkt_solve_tril import (
+    chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril,
+)
+from .utils import SUPPRESS_LEVEL
+from .wy_fast import (
+    maybe_set_tle_recompute_allocator,
+    recompute_w_u_fwd,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _chunk_size_for_sequence(T: int, is_varlen: bool) -> int:
+    if is_varlen:
+        return 64
+    return min(64, max(16, 1 << (T - 1).bit_length()))
+
+
+def chunk_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    cu_seqlens: torch.LongTensor | None = None,
+):
+    logger.debug("GEMS CHUNK GATED DELTA RULE FWD")
+    q_contiguous = q.is_contiguous()
+    k_contiguous = k.is_contiguous()
+    v_contiguous = v.is_contiguous()
+    g_contiguous = g.is_contiguous()
+    beta_contiguous = beta.is_contiguous()
+    initial_state_contiguous = initial_state is None or initial_state.is_contiguous()
+    cu_seqlens_contiguous = cu_seqlens is None or cu_seqlens.is_contiguous()
+    if not (
+        q_contiguous
+        and k_contiguous
+        and v_contiguous
+        and g_contiguous
+        and beta_contiguous
+        and initial_state_contiguous
+        and cu_seqlens_contiguous
+    ):
+        if not q_contiguous:
+            q = q.contiguous()
+        if not k_contiguous:
+            k = k.contiguous()
+        if not v_contiguous:
+            v = v.contiguous()
+        if not g_contiguous:
+            g = g.contiguous()
+        if not beta_contiguous:
+            beta = beta.contiguous()
+        if not initial_state_contiguous:
+            initial_state = initial_state.contiguous()
+        if not cu_seqlens_contiguous:
+            cu_seqlens = cu_seqlens.contiguous()
+
+    chunk_size = _chunk_size_for_sequence(q.shape[1], cu_seqlens is not None)
+    maybe_set_tle_recompute_allocator(q.device, cu_seqlens)
+
+    if initial_state is None and output_final_state:
+        try:
+            from .api import (
+                _can_use_tle_chunk_gated_delta_rule,
+                _tle_chunk_gated_delta_rule_fwd,
+            )
+
+            if _can_use_tle_chunk_gated_delta_rule(
+                q=q,
+                k=k,
+                v=v,
+                beta=beta,
+                g=g,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                cu_seqlens=cu_seqlens,
+            ):
+                g_tle, A_tle = chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
+                    g=g,
+                    k=k,
+                    beta=beta,
+                    cu_seqlens=cu_seqlens,
+                    chunk_size=chunk_size,
+                    output_dtype=k.dtype,
+                    use_g_in_kkt=False,
+                )
+                o, final_state = _tle_chunk_gated_delta_rule_fwd(
+                    q=q,
+                    k=k,
+                    v=v,
+                    g_cumsum=g_tle,
+                    beta=beta,
+                    a=A_tle,
+                    scale=float(scale),
+                )
+                g, A = chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
+                    g=g,
+                    k=k,
+                    beta=beta,
+                    cu_seqlens=cu_seqlens,
+                    chunk_size=chunk_size,
+                    output_dtype=k.dtype,
+                )
+                return g, o, A, final_state, None, None, None
+        except ImportError:
+            pass
+
+    g, A = chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
+        g=g,
+        k=k,
+        beta=beta,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        output_dtype=k.dtype,
+    )
+    block_v = 128 if v.shape[-1] == 128 else 64
+    pipe_stages = 5 if v.shape[-1] >= 256 else (3 if v.shape[-1] == 128 else 2)
+    w, u = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        g_cumsum=g,
+        cu_seqlens=cu_seqlens,
+        block_v=block_v,
+        pipe_stages=pipe_stages,
+    )
+    if SUPPRESS_LEVEL < 3 and can_use_fused_tail_vblock(
+        q=q,
+        k=k,
+        w=w,
+        u=u,
+        g=g,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
+    ):
+        o, final_state = chunk_gated_delta_rule_fused_tail_vblock(
+            q=q,
+            k=k,
+            w=w,
+            u=u,
+            g=g,
+            initial_state=initial_state,
+            scale=scale,
+        )
+        return g, o, A, final_state, None, None, None
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+        k=k,
+        w=w,
+        u=u,
+        g=g,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        chunk_size=chunk_size,
+        cu_seqlens=cu_seqlens,
+    )
+    o = chunk_fwd_o(
+        q=q,
+        k=k,
+        v=v_new,
+        h=h,
+        g=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+    )
+    if SUPPRESS_LEVEL < 3:
+        return g, o, A, final_state, None, None, None
+    elif SUPPRESS_LEVEL >= 3:
+        return g, o, A, final_state, w, h, v_new

--- a/src/flag_attn/gated_delta_rule/chunk.py
+++ b/src/flag_attn/gated_delta_rule/chunk.py
@@ -13,6 +13,10 @@ from .chunk_fused_tail_vblock import (
     can_use_fused_tail_vblock,
     chunk_gated_delta_rule_fused_tail_vblock,
 )
+from .chunk_fused_forward import (
+    can_use_two_kernel_fused_forward,
+    chunk_gdn_two_kernel_fwd,
+)
 from .chunk_o import chunk_fwd_o
 from .fused_cumsum_kkt_solve_tril import (
     chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril,
@@ -77,6 +81,35 @@ def chunk_gated_delta_rule_fwd(
 
     chunk_size = _chunk_size_for_sequence(q.shape[1], cu_seqlens is not None)
     maybe_set_tle_recompute_allocator(q.device, cu_seqlens)
+
+    if can_use_two_kernel_fused_forward(
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+    ):
+        g, A = chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
+            g=g,
+            k=k,
+            beta=beta,
+            cu_seqlens=cu_seqlens,
+            chunk_size=chunk_size,
+            output_dtype=k.dtype,
+        )
+        o, final_state = chunk_gdn_two_kernel_fwd(
+            q=q,
+            k=k,
+            v=v,
+            beta=beta,
+            A=A,
+            g=g,
+            scale=float(scale),
+        )
+        return g, o, A, final_state, None, None, None
 
     if initial_state is None and output_final_state:
         try:

--- a/src/flag_attn/gated_delta_rule/chunk_delta_h.py
+++ b/src/flag_attn/gated_delta_rule/chunk_delta_h.py
@@ -1,0 +1,370 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+
+import torch
+import triton
+import triton.language as tl
+
+from .compat import libentry, libtuner
+from .index import prepare_chunk_indices, prepare_chunk_offsets
+from .triton_ops_helper import exp
+from .utils import use_cuda_graph
+
+NUM_WARPS = [2, 4, 8, 16]
+
+
+@libentry()
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "USE_GK": lambda args: args["gk"] is not None,
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "SAVE_NEW_VALUE": lambda args: args["v_new"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@libtuner(
+    configs=[
+        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4]
+        for num_stages in [2, 3, 4]
+        for BV in [32, 64]
+    ],
+    key=[
+        "H",
+        "K",
+        "V",
+        "BT",
+        "IS_VARLEN",
+        "USE_INITIAL_STATE",
+        "STORE_FINAL_STATE",
+    ],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
+    k,
+    v,
+    w,
+    v_new,
+    g,
+    gk,
+    h,
+    h0,
+    ht,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    SAVE_NEW_VALUE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+        boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+        boh = i_n * NT
+
+    # [BK, BV]
+    b_h1 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 64:
+        b_h2 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 128:
+        b_h3 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 192:
+        b_h4 = tl.zeros([64, BV], dtype=tl.float32)
+
+    # calculate offset
+    h += ((boh * H + i_h) * K * V).to(tl.int64)
+    v += ((bos * H + i_h) * V).to(tl.int64)
+    k += ((bos * Hg + i_h // (H // Hg)) * K).to(tl.int64)
+    w += ((bos * H + i_h) * K).to(tl.int64)
+    if SAVE_NEW_VALUE:
+        v_new += ((bos * H + i_h) * V).to(tl.int64)
+    stride_v = H * V
+    stride_h = H * K * V
+    stride_k = Hg * K
+    stride_w = H * K
+    if USE_INITIAL_STATE:
+        h0 = h0 + i_nh * K * V
+    if STORE_FINAL_STATE:
+        ht = ht + i_nh * K * V
+
+    # load initial state
+    if USE_INITIAL_STATE:
+        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        if K > 64:
+            p_h0_2 = tl.make_block_ptr(
+                h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+            )
+            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+        if K > 128:
+            p_h0_3 = tl.make_block_ptr(
+                h0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+            )
+            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+        if K > 192:
+            p_h0_4 = tl.make_block_ptr(
+                h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+            )
+            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+
+    # main recurrence
+    for i_t in range(NT):
+        p_h1 = tl.make_block_ptr(
+            h + i_t * stride_h, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
+        )
+        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+        if K > 64:
+            p_h2 = tl.make_block_ptr(
+                h + i_t * stride_h,
+                (K, V),
+                (V, 1),
+                (64, i_v * BV),
+                (64, BV),
+                (1, 0),
+            )
+            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
+        if K > 128:
+            p_h3 = tl.make_block_ptr(
+                h + i_t * stride_h,
+                (K, V),
+                (V, 1),
+                (128, i_v * BV),
+                (64, BV),
+                (1, 0),
+            )
+            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
+        if K > 192:
+            p_h4 = tl.make_block_ptr(
+                h + i_t * stride_h,
+                (K, V),
+                (V, 1),
+                (192, i_v * BV),
+                (64, BV),
+                (1, 0),
+            )
+            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+
+        p_w = tl.make_block_ptr(
+            w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0)
+        )
+        b_w = tl.load(p_w, boundary_check=(0, 1))
+        b_v = tl.dot(b_w, b_h1.to(b_w.dtype))
+        if K > 64:
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
+            )
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, b_h2.to(b_w.dtype))
+        if K > 128:
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
+            )
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, b_h3.to(b_w.dtype))
+        if K > 192:
+            p_w = tl.make_block_ptr(
+                w, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
+            )
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v += tl.dot(b_w, b_h4.to(b_w.dtype))
+        p_v = tl.make_block_ptr(
+            v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+
+        if SAVE_NEW_VALUE:
+            p_v = tl.make_block_ptr(
+                v_new,
+                (T, V),
+                (stride_v, 1),
+                (i_t * BT, i_v * BV),
+                (BT, BV),
+                (1, 0),
+            )
+            tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
+
+        last_idx = min((i_t + 1) * BT, T) - 1
+        if USE_G:
+            m_t = (i_t * BT + tl.arange(0, BT)) < T
+            b_g_last = tl.load(g + bos * H + last_idx * H + i_h).to(tl.float32)
+            p_g = tl.make_block_ptr(
+                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+            )
+            b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+            b_v = b_v * tl.where(m_t, exp(b_g_last - b_g), 0)[:, None]
+            b_g_last = exp(b_g_last)
+            b_h1 *= b_g_last
+            if K > 64:
+                b_h2 *= b_g_last
+            if K > 128:
+                b_h3 *= b_g_last
+            if K > 192:
+                b_h4 *= b_g_last
+
+        if USE_GK:
+            o_k1 = tl.arange(0, 64)
+            b_gk_last1 = tl.load(
+                gk + (bos + last_idx) * H * K + i_h * K + o_k1,
+                mask=(o_k1 < K),
+                other=0.0,
+            ).to(tl.float32)
+            b_h1 *= exp(b_gk_last1)[:, None]
+            if K > 64:
+                o_k2 = 64 + o_k1
+                b_gk_last2 = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k2,
+                    mask=(o_k2 < K),
+                    other=0.0,
+                ).to(tl.float32)
+                b_h2 *= exp(b_gk_last2)[:, None]
+            if K > 128:
+                o_k3 = 128 + o_k1
+                b_gk_last3 = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k3,
+                    mask=(o_k3 < K),
+                    other=0.0,
+                ).to(tl.float32)
+                b_h3 *= exp(b_gk_last3)[:, None]
+            if K > 192:
+                o_k4 = 192 + o_k1
+                b_gk_last4 = tl.load(
+                    gk + (bos + last_idx) * H * K + i_h * K + o_k4,
+                    mask=(o_k4 < K),
+                    other=0.0,
+                ).to(tl.float32)
+                b_h4 *= exp(b_gk_last4)[:, None]
+        b_v = b_v.to(k.dtype.element_ty)
+
+        p_k = tl.make_block_ptr(
+            k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
+        )
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_h1 += tl.dot(b_k, b_v)
+        if K > 64:
+            p_k = tl.make_block_ptr(
+                k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h2 += tl.dot(b_k, b_v)
+        if K > 128:
+            p_k = tl.make_block_ptr(
+                k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h3 += tl.dot(b_k, b_v)
+        if K > 192:
+            p_k = tl.make_block_ptr(
+                k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
+            )
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h4 += tl.dot(b_k, b_v)
+    # epilogue
+    if STORE_FINAL_STATE:
+        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
+        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 64:
+            p_ht = tl.make_block_ptr(
+                ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+            )
+            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 128:
+            p_ht = tl.make_block_ptr(
+                ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+            )
+            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 192:
+            p_ht = tl.make_block_ptr(
+                ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+            )
+            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_gated_delta_rule_fwd_h(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    chunk_size: int = 64,  # SY: remove this argument and force chunk size 64?
+    save_new_value: bool = True,
+    cu_seqlens: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # This kernel is slightly different from fla to support Q/K with different head numbers.
+    # In fla, Q/K always have the same head number, so Hg is always equal to H.
+    B, T, Hg, K, V = *k.shape, u.shape[-1]
+    H = u.shape[-2]
+    BT = chunk_size
+
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, chunk_size)
+        if cu_seqlens is not None
+        else None
+    )
+    # N: the actual number of sequences in the batch with either equal or variable lengths
+    if cu_seqlens is None:
+        N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
+    else:
+        N, NT, chunk_offsets = (
+            len(cu_seqlens) - 1,
+            len(chunk_indices),
+            prepare_chunk_offsets(cu_seqlens, BT),
+        )
+    assert K <= 256, "current kernel does not support head dimension larger than 256."
+
+    h = k.new_empty(B, NT, H, K, V)
+    final_state = (
+        k.new_empty(N, H, K, V, dtype=torch.float32) if output_final_state else None
+    )
+
+    v_new = torch.empty_like(u) if save_new_value else None
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), N * H)
+
+    chunk_gated_delta_rule_fwd_kernel_h_blockdim64[grid](
+        k=k,
+        v=u,
+        w=w,
+        v_new=v_new,
+        g=g,
+        gk=gk,
+        h=h,
+        h0=initial_state,
+        ht=final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return h, v_new, final_state

--- a/src/flag_attn/gated_delta_rule/chunk_fused_forward.py
+++ b/src/flag_attn/gated_delta_rule/chunk_fused_forward.py
@@ -1,0 +1,383 @@
+# This file contains code derived from the flash-linear-attention project.
+# The original source code is licensed under the MIT license.
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from .compat import has_triton_tle, libentry, libtuner
+
+TWO_KERNEL_TLE_ENV = "FLAG_ATTN_CHUNK_GDR_TWO_KERNEL_TLE"
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TWO_KERNEL_TLE = True
+    except ImportError:
+        tle = None
+        HAS_TWO_KERNEL_TLE = False
+else:
+    tle = None
+    HAS_TWO_KERNEL_TLE = False
+
+
+def can_use_two_kernel_fused_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None,
+) -> bool:
+    enabled = os.environ.get(TWO_KERNEL_TLE_ENV, "1").lower()
+    if not (HAS_TWO_KERNEL_TLE and enabled not in {"0", "false", "off", "no"}):
+        return False
+    if initial_state is not None or not output_final_state or cu_seqlens is not None:
+        return False
+    if q.device.type != "cuda" or q.dtype not in (torch.float16, torch.bfloat16):
+        return False
+    if not all(x.device == q.device and x.dtype == q.dtype for x in (k, v, beta, g)):
+        return False
+    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+        return False
+    if beta.ndim != 3 or g.ndim != 3:
+        return False
+
+    B, T, Hg, K = q.shape
+    H, V = v.shape[2:]
+    return (
+        k.shape == (B, T, Hg, K)
+        and v.shape[:2] == (B, T)
+        and beta.shape == (B, T, H)
+        and g.shape == (B, T, H)
+        and H % Hg == 0
+        and B * H >= 64
+        and K in {64, 128, 256}
+        and V > 0
+        and T > 0
+        and T % 64 == 0
+    )
+
+
+if HAS_TWO_KERNEL_TLE:
+
+    @libentry()
+    @libtuner(
+        configs=[
+            triton.Config({"BV": 64}, num_warps=4, num_stages=1),
+            triton.Config({"BV": 64}, num_warps=4, num_stages=3),
+            triton.Config({"BV": 32}, num_warps=2, num_stages=2),
+        ],
+        key=["H", "Hg", "K", "V", "BT"],
+    )
+    @triton.jit(do_not_specialize=["T"])
+    def _chunk_gdn_two_kernel_fwd_kernel(
+        q,
+        k,
+        v,
+        beta,
+        A,
+        g,
+        o,
+        final_state,
+        scale,
+        T,
+        H: tl.constexpr,
+        Hg: tl.constexpr,
+        K: tl.constexpr,
+        V: tl.constexpr,
+        BT: tl.constexpr,
+        BV: tl.constexpr,
+    ):
+        i_v, i_bh = tl.program_id(0), tl.program_id(1)
+        i_b, i_h = i_bh // H, i_bh % H
+        i_qh = i_h // (H // Hg)
+        bos = i_b * T
+        NT = tl.cdiv(T, BT)
+
+        q += (bos * Hg + i_qh).to(tl.int64) * K
+        k += (bos * Hg + i_qh).to(tl.int64) * K
+        v += (bos * H + i_h).to(tl.int64) * V
+        beta += bos * H + i_h
+        A += (bos * H + i_h).to(tl.int64) * BT
+        g += bos * H + i_h
+        o += (bos * H + i_h).to(tl.int64) * V
+
+        b_h1 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 64:
+            b_h2 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 128:
+            b_h3 = tl.zeros([64, BV], dtype=tl.float32)
+        if K > 192:
+            b_h4 = tl.zeros([64, BV], dtype=tl.float32)
+
+        for i_t in range(NT):
+            o_t = i_t * BT + tl.arange(0, BT)
+            m_t = o_t < T
+
+            p_A = tl.make_block_ptr(
+                A,
+                (T, BT),
+                (H * BT, 1),
+                (i_t * BT, 0),
+                (BT, BT),
+                (1, 0),
+            )
+            b_inv = tl.load(p_A, boundary_check=(0, 1))
+            p_beta = tl.make_block_ptr(beta, (T,), (H,), (i_t * BT,), (BT,), (0,))
+            b_beta = tl.load(p_beta, boundary_check=(0,))
+
+            last_idx = min((i_t + 1) * BT, T) - 1
+            b_g_last = tl.load(g + last_idx * H).to(tl.float32)
+            p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
+            b_g = tle.load(p_g, boundary_check=(0,), is_async=True).to(tl.float32)
+            b_g_exp = tl.math.exp2(b_g * 1.4426950408889634)
+            b_g_last_exp = tl.math.exp2(b_g_last * 1.4426950408889634)
+
+            p_v = tl.make_block_ptr(
+                v,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT, i_v * BV),
+                (BT, BV),
+                (1, 0),
+            )
+            b_v_input = tle.load(p_v, boundary_check=(0, 1), is_async=True)
+            b_v_beta = (b_v_input * b_beta[:, None]).to(b_v_input.dtype)
+            b_u = tl.dot(b_inv, b_v_beta, allow_tf32=False)
+            b_v_new = b_u.to(v.dtype.element_ty).to(tl.float32)
+
+            p_k1 = tl.make_block_ptr(
+                k, (T, K), (Hg * K, 1), (i_t * BT, 0), (BT, 64), (1, 0)
+            )
+            b_k1 = tle.load(p_k1, boundary_check=(0, 1), is_async=True)
+            b_kb1 = b_k1 * b_beta[:, None] * b_g_exp[:, None]
+            b_w1 = tl.dot(b_inv, b_kb1.to(b_k1.dtype))
+            b_v_new -= tl.dot(b_w1.to(b_k1.dtype), b_h1.to(b_k1.dtype))
+
+            if K > 64:
+                p_k2 = tl.make_block_ptr(
+                    k,
+                    (T, K),
+                    (Hg * K, 1),
+                    (i_t * BT, 64),
+                    (BT, 64),
+                    (1, 0),
+                )
+                b_k2 = tle.load(p_k2, boundary_check=(0, 1), is_async=True)
+                b_kb2 = b_k2 * b_beta[:, None] * b_g_exp[:, None]
+                b_w2 = tl.dot(b_inv, b_kb2.to(b_k2.dtype))
+                b_v_new -= tl.dot(b_w2.to(b_k2.dtype), b_h2.to(b_k2.dtype))
+
+            if K > 128:
+                p_k3 = tl.make_block_ptr(
+                    k,
+                    (T, K),
+                    (Hg * K, 1),
+                    (i_t * BT, 128),
+                    (BT, 64),
+                    (1, 0),
+                )
+                b_k3 = tle.load(p_k3, boundary_check=(0, 1), is_async=True)
+                b_kb3 = b_k3 * b_beta[:, None] * b_g_exp[:, None]
+                b_w3 = tl.dot(b_inv, b_kb3.to(b_k3.dtype))
+                b_v_new -= tl.dot(b_w3.to(b_k3.dtype), b_h3.to(b_k3.dtype))
+
+            if K > 192:
+                p_k4 = tl.make_block_ptr(
+                    k,
+                    (T, K),
+                    (Hg * K, 1),
+                    (i_t * BT, 192),
+                    (BT, 64),
+                    (1, 0),
+                )
+                b_k4 = tle.load(p_k4, boundary_check=(0, 1), is_async=True)
+                b_kb4 = b_k4 * b_beta[:, None] * b_g_exp[:, None]
+                b_w4 = tl.dot(b_inv, b_kb4.to(b_k4.dtype))
+                b_v_new -= tl.dot(b_w4.to(b_k4.dtype), b_h4.to(b_k4.dtype))
+
+            b_v_decay = (
+                b_v_new
+                * tl.where(
+                    m_t,
+                    tl.math.exp2((b_g_last - b_g) * 1.4426950408889634),
+                    0,
+                )[:, None]
+            )
+            b_v_state = b_v_decay.to(k.dtype.element_ty)
+            b_v_o = b_v_new.to(k.dtype.element_ty)
+            b_o = tl.zeros([BT, BV], dtype=tl.float32)
+            b_qk = tl.zeros([BT, BT], dtype=tl.float32)
+
+            p_q1 = tl.make_block_ptr(
+                q, (T, K), (Hg * K, 1), (i_t * BT, 0), (BT, 64), (1, 0)
+            )
+            p_kt1 = tl.make_block_ptr(
+                k, (K, T), (1, Hg * K), (0, i_t * BT), (64, BT), (0, 1)
+            )
+            b_q1 = tle.load(p_q1, boundary_check=(0, 1), is_async=True)
+            b_kt1 = tle.load(p_kt1, boundary_check=(0, 1), is_async=True)
+            b_o += tl.dot(b_q1, b_h1.to(b_q1.dtype))
+            b_qk += tl.dot(b_q1, b_kt1)
+            b_h1 *= b_g_last_exp
+            b_h1 += tl.dot(b_kt1, b_v_state)
+
+            if K > 64:
+                p_q2 = tl.make_block_ptr(
+                    q,
+                    (T, K),
+                    (Hg * K, 1),
+                    (i_t * BT, 64),
+                    (BT, 64),
+                    (1, 0),
+                )
+                p_kt2 = tl.make_block_ptr(
+                    k,
+                    (K, T),
+                    (1, Hg * K),
+                    (64, i_t * BT),
+                    (64, BT),
+                    (0, 1),
+                )
+                b_q2 = tle.load(p_q2, boundary_check=(0, 1), is_async=True)
+                b_kt2 = tle.load(p_kt2, boundary_check=(0, 1), is_async=True)
+                b_o += tl.dot(b_q2, b_h2.to(b_q2.dtype))
+                b_qk += tl.dot(b_q2, b_kt2)
+                b_h2 *= b_g_last_exp
+                b_h2 += tl.dot(b_kt2, b_v_state)
+
+            if K > 128:
+                p_q3 = tl.make_block_ptr(
+                    q,
+                    (T, K),
+                    (Hg * K, 1),
+                    (i_t * BT, 128),
+                    (BT, 64),
+                    (1, 0),
+                )
+                p_kt3 = tl.make_block_ptr(
+                    k,
+                    (K, T),
+                    (1, Hg * K),
+                    (128, i_t * BT),
+                    (64, BT),
+                    (0, 1),
+                )
+                b_q3 = tle.load(p_q3, boundary_check=(0, 1), is_async=True)
+                b_kt3 = tle.load(p_kt3, boundary_check=(0, 1), is_async=True)
+                b_o += tl.dot(b_q3, b_h3.to(b_q3.dtype))
+                b_qk += tl.dot(b_q3, b_kt3)
+                b_h3 *= b_g_last_exp
+                b_h3 += tl.dot(b_kt3, b_v_state)
+
+            if K > 192:
+                p_q4 = tl.make_block_ptr(
+                    q,
+                    (T, K),
+                    (Hg * K, 1),
+                    (i_t * BT, 192),
+                    (BT, 64),
+                    (1, 0),
+                )
+                p_kt4 = tl.make_block_ptr(
+                    k,
+                    (K, T),
+                    (1, Hg * K),
+                    (192, i_t * BT),
+                    (64, BT),
+                    (0, 1),
+                )
+                b_q4 = tle.load(p_q4, boundary_check=(0, 1), is_async=True)
+                b_kt4 = tle.load(p_kt4, boundary_check=(0, 1), is_async=True)
+                b_o += tl.dot(b_q4, b_h4.to(b_q4.dtype))
+                b_qk += tl.dot(b_q4, b_kt4)
+                b_h4 *= b_g_last_exp
+                b_h4 += tl.dot(b_kt4, b_v_state)
+
+            b_o *= b_g_exp[:, None]
+            b_qk *= tl.math.exp2((b_g[:, None] - b_g[None, :]) * 1.4426950408889634)
+            m_qk = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t[None, :])
+            b_qk = tl.where(m_qk, b_qk, 0)
+            b_o = (b_o + tl.dot(b_qk.to(b_v_o.dtype), b_v_o)) * scale
+
+            p_o = tl.make_block_ptr(
+                o,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT, i_v * BV),
+                (BT, BV),
+                (1, 0),
+            )
+            tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+        o_k = tl.arange(0, 64)
+        o_v = i_v * BV + tl.arange(0, BV)
+        m_v = o_v < V
+        state_base = final_state + (i_bh * K * V).to(tl.int64)
+        tl.store(
+            state_base + o_k[:, None] * V + o_v[None, :],
+            b_h1,
+            mask=m_v[None, :],
+        )
+        if K > 64:
+            tl.store(
+                state_base + (o_k[:, None] + 64) * V + o_v[None, :],
+                b_h2,
+                mask=m_v[None, :],
+            )
+        if K > 128:
+            tl.store(
+                state_base + (o_k[:, None] + 128) * V + o_v[None, :],
+                b_h3,
+                mask=m_v[None, :],
+            )
+        if K > 192:
+            tl.store(
+                state_base + (o_k[:, None] + 192) * V + o_v[None, :],
+                b_h4,
+                mask=m_v[None, :],
+            )
+
+
+def chunk_gdn_two_kernel_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    g: torch.Tensor,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, Hg, K = q.shape
+    H, V = v.shape[2:]
+    BT = A.shape[-1]
+    o = torch.empty_like(v)
+    final_state = torch.empty((B, H, K, V), dtype=torch.float32, device=v.device)
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), B * H)
+
+    _chunk_gdn_two_kernel_fwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        g=g,
+        o=o,
+        final_state=final_state,
+        scale=scale,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return o, final_state

--- a/src/flag_attn/gated_delta_rule/chunk_fused_tail_vblock.py
+++ b/src/flag_attn/gated_delta_rule/chunk_fused_tail_vblock.py
@@ -1,0 +1,170 @@
+# V-blocked fused tail for the official K=V=BT=64 chunk_gated_delta_rule path.
+
+import torch
+import triton
+import triton.language as tl
+
+from .compat import libentry
+
+_FUSED_TAIL_BV = 16
+
+
+def can_use_fused_tail_vblock(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+    *,
+    chunk_size: int,
+    cu_seqlens: torch.Tensor | None,
+) -> bool:
+    if cu_seqlens is not None or initial_state is None or not output_final_state:
+        return False
+    if q.ndim != 4 or k.ndim != 4 or w.ndim != 4 or u.ndim != 4 or g.ndim != 3:
+        return False
+
+    B, T, Hg, K = q.shape
+    H, V = u.shape[2], u.shape[3]
+    if k.shape != (B, T, Hg, K):
+        return False
+    if w.shape != (B, T, H, K) or g.shape != (B, T, H):
+        return False
+    if initial_state.shape != (B, H, K, V):
+        return False
+    if chunk_size != 64 or T % 64 != 0 or (K, V) != (64, 64) or H % Hg != 0:
+        return False
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        return False
+    if not all(x.dtype == q.dtype for x in (k, w, u, g, initial_state)):
+        return False
+    return all(x.is_contiguous() for x in (q, k, w, u, g, initial_state))
+
+
+@libentry()
+@triton.jit
+def _chunk_gated_delta_rule_fused_tail_vblock_kernel(
+    q,
+    k,
+    w,
+    u,
+    g,
+    h0,
+    o,
+    ht,
+    scale: tl.constexpr,
+    T: tl.constexpr,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    BT: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BV: tl.constexpr,
+):
+    i_v = tl.program_id(0)
+    i_bh = tl.program_id(1)
+    i_b = i_bh // H
+    i_h = i_bh % H
+    i_hg = i_h // (H // Hg)
+
+    offs_t = tl.arange(0, BT)
+    offs_k = tl.arange(0, K)
+    offs_v = i_v * BV + tl.arange(0, BV)
+    v_mask = offs_v < V
+
+    h0_base = ((i_b * H + i_h) * K) * V
+    h_acc = tl.load(
+        h0 + h0_base + offs_k[:, None] * V + offs_v[None, :],
+        mask=v_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+
+    for i_t in range(0, tl.cdiv(T, BT)):
+        t = i_t * BT + offs_t
+
+        q_block = tl.load(
+            q + (((i_b * T + t[:, None]) * Hg + i_hg) * K + offs_k[None, :])
+        )
+        k_t_block = tl.load(
+            k + (((i_b * T + t[None, :]) * Hg + i_hg) * K + offs_k[:, None])
+        )
+        w_block = tl.load(
+            w + (((i_b * T + t[:, None]) * H + i_h) * K + offs_k[None, :])
+        )
+        u_block = tl.load(
+            u + (((i_b * T + t[:, None]) * H + i_h) * V + offs_v[None, :]),
+            mask=v_mask[None, :],
+            other=0.0,
+        )
+        g_vec = tl.load(g + (i_b * T + t) * H + i_h).to(tl.float32)
+
+        residual = u_block.to(tl.float32) - tl.dot(w_block, h_acc.to(w_block.dtype))
+
+        q_h = tl.dot(q_block, h_acc.to(q_block.dtype))
+        qk = tl.dot(q_block, k_t_block).to(tl.float32)
+        causal = offs_t[:, None] >= offs_t[None, :]
+        qk = tl.where(causal, qk * tl.exp(g_vec[:, None] - g_vec[None, :]), 0.0)
+        out = (
+            q_h * tl.exp(g_vec)[:, None]
+            + tl.dot(qk.to(u_block.dtype), residual.to(u_block.dtype))
+        ) * scale
+        tl.store(
+            o + (((i_b * T + t[:, None]) * H + i_h) * V + offs_v[None, :]),
+            out,
+            mask=v_mask[None, :],
+        )
+
+        g_last = tl.load(g + (i_b * T + ((i_t + 1) * BT - 1)) * H + i_h).to(tl.float32)
+        residual_for_state = residual * tl.exp(g_last - g_vec)[:, None]
+        h_acc = h_acc * tl.exp(g_last) + tl.dot(
+            k_t_block, residual_for_state.to(k_t_block.dtype)
+        )
+
+    ht_base = ((i_b * H + i_h) * K) * V
+    tl.store(
+        ht + ht_base + offs_k[:, None] * V + offs_v[None, :],
+        h_acc,
+        mask=v_mask[None, :],
+    )
+
+
+def chunk_gated_delta_rule_fused_tail_vblock(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: torch.Tensor,
+    initial_state: torch.Tensor,
+    *,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, Hg, K = q.shape
+    H, V = u.shape[2], u.shape[3]
+
+    o = torch.empty_like(u)
+    final_state = torch.empty(B, H, K, V, device=q.device, dtype=torch.float32)
+    _chunk_gated_delta_rule_fused_tail_vblock_kernel[
+        (triton.cdiv(V, _FUSED_TAIL_BV), B * H)
+    ](
+        q,
+        k,
+        w,
+        u,
+        g,
+        initial_state,
+        o,
+        final_state,
+        scale=scale,
+        T=T,
+        H=H,
+        Hg=Hg,
+        BT=64,
+        K=64,
+        V=64,
+        BV=_FUSED_TAIL_BV,
+        num_warps=4,
+        num_stages=3,
+    )
+    return o, final_state

--- a/src/flag_attn/gated_delta_rule/chunk_gated_delta_direct.py
+++ b/src/flag_attn/gated_delta_rule/chunk_gated_delta_direct.py
@@ -1,0 +1,183 @@
+# This file contains a guarded direct forward path for small chunk_gated_delta_rule
+# shapes. It follows the recurrent definition directly and falls back to the
+# chunk decomposition for unsupported cases.
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from .compat import libentry
+from .triton_ops_helper import exp
+
+_DIRECT_MAX_T = 128
+_DIRECT_MAX_K = 128
+_DIRECT_MAX_V = 128
+_DIRECT_BV = 32
+
+
+@libentry()
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["initial_state"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["final_state"] is not None,
+    }
+)
+@triton.jit
+def _chunk_gated_delta_rule_direct_fwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    o,
+    initial_state,
+    final_state,
+    scale,
+    T: tl.constexpr,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+):
+    i_v = tl.program_id(0)
+    i_bh = tl.program_id(1)
+    i_b = i_bh // H
+    i_h = i_bh % H
+    i_hg = i_h // (H // Hg)
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_k[:, None] & mask_v[None, :]
+
+    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        p_h0 = (
+            initial_state + ((i_b * H + i_h) * K * V) + o_k[:, None] * V + o_v[None, :]
+        )
+        b_h += tl.load(p_h0, mask=mask_h, other=0.0).to(tl.float32)
+
+    q_base = q + ((i_b * T * Hg + i_hg) * K)
+    k_base = k + ((i_b * T * Hg + i_hg) * K)
+    v_base = v + ((i_b * T * H + i_h) * V)
+    o_base = o + ((i_b * T * H + i_h) * V)
+    g_base = g + i_b * T * H + i_h
+    beta_base = beta + i_b * T * H + i_h
+    for i_t in range(0, T):
+        b_q = tl.load(q_base + i_t * Hg * K + o_k, mask=mask_k, other=0.0).to(
+            tl.float32
+        )
+        b_k = tl.load(k_base + i_t * Hg * K + o_k, mask=mask_k, other=0.0).to(
+            tl.float32
+        )
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_q = b_q / tl.maximum(tl.sqrt(tl.sum(b_q * b_q)), 1e-6)
+            b_k = b_k / tl.maximum(tl.sqrt(tl.sum(b_k * b_k)), 1e-6)
+        b_v = tl.load(v_base + i_t * H * V + o_v, mask=mask_v, other=0.0).to(tl.float32)
+        b_g = tl.load(g_base + i_t * H).to(tl.float32)
+        b_beta = tl.load(beta_base + i_t * H).to(tl.float32)
+
+        b_h *= exp(b_g)
+        b_v = (b_v - tl.sum(b_h * b_k[:, None], axis=0)) * b_beta
+        b_h += b_k[:, None] * b_v[None, :]
+        b_o = tl.sum(b_h * (b_q * scale)[:, None], axis=0)
+        tl.store(
+            o_base + i_t * H * V + o_v,
+            b_o.to(o.dtype.element_ty),
+            mask=mask_v,
+        )
+
+    if STORE_FINAL_STATE:
+        p_ht = final_state + ((i_b * H + i_h) * K * V) + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+
+
+def can_use_chunk_gated_delta_rule_direct(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None,
+    cu_seqlens: torch.LongTensor | None,
+) -> bool:
+    if cu_seqlens is not None:
+        return False
+    if initial_state is not None:
+        return False
+    if not (q.is_contiguous() and k.is_contiguous() and v.is_contiguous()):
+        return False
+    if not (g.is_contiguous() and beta.is_contiguous()):
+        return False
+    B, T, Hg, K = q.shape
+    Bv, Tv, H, V = v.shape
+    return (
+        B == Bv
+        and T == Tv
+        and 0 < T <= _DIRECT_MAX_T
+        and 0 < K <= _DIRECT_MAX_K
+        and 0 < V <= _DIRECT_MAX_V
+        and H % Hg == 0
+        and q.dtype in (torch.float16, torch.bfloat16, torch.float32)
+    )
+
+
+def chunk_gated_delta_rule_direct_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    B, T, Hg, K = q.shape
+    H, V = v.shape[2], v.shape[3]
+    BK = triton.next_power_of_2(K)
+    use_one_warp = (K <= 16 and V <= 16) or (
+        q.dtype == torch.float32 and K <= 32 and V <= 32
+    )
+    BV = min(triton.next_power_of_2(V), 16 if use_one_warp else _DIRECT_BV)
+
+    o = torch.empty_like(v)
+    final_state = (
+        torch.empty(B, H, K, V, device=v.device, dtype=torch.float32)
+        if output_final_state
+        else None
+    )
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), B * H)
+
+    _chunk_gated_delta_rule_direct_fwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        o=o,
+        initial_state=initial_state,
+        final_state=final_state,
+        scale=float(scale),
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        num_warps=1 if use_one_warp else (4 if K >= 128 else 2),
+        num_stages=1 if K <= 16 and V <= 16 else (2 if use_one_warp else 3),
+    )
+    return o, final_state

--- a/src/flag_attn/gated_delta_rule/chunk_o.py
+++ b/src/flag_attn/gated_delta_rule/chunk_o.py
@@ -1,0 +1,190 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+# ruff: noqa: E501
+
+import torch
+import triton
+import triton.language as tl
+
+from .compat import libentry, libtuner
+from .index import prepare_chunk_indices
+from .triton_ops_helper import exp
+from .utils import (
+    FLA_GDN_FIX_BT,
+    check_shared_mem,
+    is_nvidia_hopper,
+)
+
+BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
+NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
+
+
+@libentry()
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@libtuner(
+    configs=[
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in BKV_LIST
+        for BV in BKV_LIST
+        for num_warps in NUM_WARPS
+        for num_stages in [2, 3, 4]
+    ],
+    key=["H", "K", "V", "BT", "IS_VARLEN"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_fwd_kernel_o(
+    q,
+    k,
+    v,
+    h,
+    g,
+    o,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    # offset calculation
+    q += (bos * Hg + i_h // (H // Hg)) * K
+    k += (bos * Hg + i_h // (H // Hg)) * K
+    v += (bos * H + i_h) * V
+    o += (bos * H + i_h) * V
+    h += (i_tg * H + i_h).to(tl.int64) * K * V
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    b_A = tl.zeros([BT, BT], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_q = tl.make_block_ptr(
+            q, (T, K), (Hg * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+        )
+        p_k = tl.make_block_ptr(
+            k, (K, T), (1, Hg * K), (i_k * BK, i_t * BT), (BK, BT), (0, 1)
+        )
+        p_h = tl.make_block_ptr(
+            h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+        )
+        # [BT, BK]
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        # [BK, BT]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        # [BK, BV]
+        b_h = tl.load(p_h, boundary_check=(0, 1))
+
+        # [BT, BK] @ [BK, BV] -> [BT, BV]
+        b_o += tl.dot(b_q, b_h)
+        # [BT, BK] @ [BK, BT] -> [BT, BT]
+        b_A += tl.dot(b_q, b_k)
+
+    if USE_G:
+        g += bos * H + i_h
+        p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
+        b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+        b_o = b_o * exp(b_g)[:, None]
+        b_A = b_A * exp(b_g[:, None] - b_g[None, :])
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    m_A = (o_t[:, None] >= o_t[None, :]) & (m_t[:, None] & m_t)
+    b_A = tl.where(m_A, b_A, 0)
+
+    p_v = tl.make_block_ptr(
+        v, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+    )
+    p_o = tl.make_block_ptr(
+        o, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+    )
+    b_v = tl.load(p_v, boundary_check=(0, 1))
+
+    # to fix mma -> mma layout conversion
+    # already solved by triton v3.2 or higher
+    b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_fwd_o(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    g: torch.Tensor | None = None,  # cumsum of log decay
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+) -> torch.Tensor:
+    B, T, Hg, K, V = *q.shape, v.shape[-1]
+    H = v.shape[-2]
+    BT = 64 if FLA_GDN_FIX_BT else min(chunk_size, max(16, triton.next_power_of_2(T)))
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
+    )
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    o = torch.empty_like(v)
+
+    def grid(meta):
+        # In varlen mode chunk_indices owns the sequence mapping and the batch
+        # id derived from i_bh is unused; use H programs to avoid duplicate work.
+        return (
+            triton.cdiv(V, meta["BV"]),
+            NT,
+            H if cu_seqlens is not None else B * H,
+        )
+
+    chunk_fwd_kernel_o[grid](
+        q,
+        k,
+        v,
+        h,
+        g,
+        o,
+        cu_seqlens,
+        chunk_indices,
+        scale,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return o

--- a/src/flag_attn/gated_delta_rule/compat.py
+++ b/src/flag_attn/gated_delta_rule/compat.py
@@ -1,0 +1,50 @@
+"""Small compatibility helpers for the vendored GDN Triton kernels."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from typing import Any, TypeVar
+
+import triton
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def libentry() -> Callable[[F], F]:
+    """Keep FlagGems kernel declarations usable without its runtime wrapper."""
+
+    def decorator(fn: F) -> F:
+        return fn
+
+    return decorator
+
+
+def libtuner(
+    *,
+    configs: Sequence[triton.Config],
+    key: Sequence[str],
+    use_cuda_graph: bool = False,
+    **kwargs: Any,
+):
+    """Map FlagGems autotuning metadata to Triton's native autotuner."""
+
+    del use_cuda_graph
+    return triton.autotune(configs=list(configs), key=list(key), **kwargs)
+
+
+def _triton_version() -> tuple[int, int, int]:
+    parts = re.findall(r"\d+", str(getattr(triton, "__version__", "0.0.0")))
+    values = [int(part) for part in parts[:3]]
+    return tuple((values + [0, 0, 0])[:3])
+
+
+def has_triton_tle(major: int = 0, minor: int = 0, patch: int = 0) -> bool:
+    if _triton_version() < (major, minor, patch):
+        return False
+    try:
+        import triton.experimental.tle.language  # noqa: F401
+    except ImportError:
+        return False
+    return True

--- a/src/flag_attn/gated_delta_rule/fused_cumsum_kkt_solve_tril.py
+++ b/src/flag_attn/gated_delta_rule/fused_cumsum_kkt_solve_tril.py
@@ -1,0 +1,470 @@
+# Copyright (c) 2025 FlagGems. All rights reserved.
+# Fused cumsum + KKT + solve_tril for chunk_gated_delta_rule. Returns g_out, A_inv; w_u is separate.
+# License: Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)
+
+from __future__ import annotations
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from .compat import libentry, libtuner
+from .index import prepare_chunk_indices
+from .triton_ops_helper import exp, make_tensor_descriptor
+from .utils import is_tma_supported
+
+
+FLA_TRIL_PRECISION = os.environ.get("FLAG_ATTN_TRIL_PRECISION", "ieee")
+ALLOWED_TRIL_PRECISIONS = {"ieee", "tf32", "tf32x3"}
+if FLA_TRIL_PRECISION not in ALLOWED_TRIL_PRECISIONS:
+    raise ValueError(
+        "FLAG_ATTN_TRIL_PRECISION must be one of "
+        f"{sorted(ALLOWED_TRIL_PRECISIONS)}, got {FLA_TRIL_PRECISION}"
+    )
+
+
+@libentry()
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_G": lambda args: args.get("USE_G", True),
+    }
+)
+@libtuner(
+    configs=[
+        triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64, 128]
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["H", "K", "BT", "IS_VARLEN"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril_kernel(
+    g_in,
+    g_out,
+    k,
+    beta,
+    A,
+    A_inv,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_TMA: tl.constexpr,
+    DOT_PRECISION: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    # ---------- cumsum ----------
+    p_g_in = tl.make_block_ptr(
+        g_in + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+    )
+    p_g_out = tl.make_block_ptr(
+        g_out + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+    )
+    b_g = tl.load(p_g_in, boundary_check=(0,)).to(tl.float32)
+    b_g = tl.cumsum(b_g, axis=0)
+    tl.store(p_g_out, b_g.to(p_g_out.dtype.element_ty), boundary_check=(0,))
+
+    # ---------- KKT (write L to A) ----------
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    p_beta = tl.make_block_ptr(
+        beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+    )
+    b_beta = tl.load(p_beta, boundary_check=(0,))
+    b_A = tl.zeros([BT, BT], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k = tl.make_block_ptr(
+            k + (bos * Hg + i_h // (H // Hg)) * K,
+            (T, K),
+            (Hg * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_kb = b_k * b_beta[:, None]
+        b_A += tl.dot(b_kb.to(b_k.dtype), tl.trans(b_k))
+    if USE_G:
+        b_g_diff = b_g[:, None] - b_g[None, :]
+        b_A = b_A * exp(b_g_diff)
+    m_A_kkt = (o_t[:, None] > o_t[None, :]) & (m_t[:, None] & m_t)
+    b_A = tl.where(m_A_kkt, b_A, 0)
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, 0),
+        (BT, BT),
+        (1, 0),
+    )
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+
+    # ---------- solve_tril (read A, write A_inv) ----------
+    o_i = tl.arange(0, 16)
+    m_A = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+    A_base = A + (bos * H + i_h) * BT
+    A_inv_base = A_inv + (bos * H + i_h) * BT
+
+    if not USE_TMA:
+        p_A_11 = tl.make_block_ptr(
+            A_base, (T, BT), (H * BT, 1), (i_t * BT, 0), (16, 16), (1, 0)
+        )
+        p_A_22 = tl.make_block_ptr(
+            A_base, (T, BT), (H * BT, 1), (i_t * BT + 16, 16), (16, 16), (1, 0)
+        )
+        p_A_33 = tl.make_block_ptr(
+            A_base, (T, BT), (H * BT, 1), (i_t * BT + 32, 32), (16, 16), (1, 0)
+        )
+        p_A_44 = tl.make_block_ptr(
+            A_base, (T, BT), (H * BT, 1), (i_t * BT + 48, 48), (16, 16), (1, 0)
+        )
+        b_Ai_11 = tl.load(p_A_11, boundary_check=(0, 1)).to(tl.float32)
+        b_Ai_22 = tl.load(p_A_22, boundary_check=(0, 1)).to(tl.float32)
+        b_Ai_33 = tl.load(p_A_33, boundary_check=(0, 1)).to(tl.float32)
+        b_Ai_44 = tl.load(p_A_44, boundary_check=(0, 1)).to(tl.float32)
+    else:
+        desc = make_tensor_descriptor(A_base, [T, BT], [H * BT, 1], [16, 16])
+        b_Ai_11 = desc.load([i_t * BT + 0, 0]).to(tl.float32)
+        b_Ai_22 = desc.load([i_t * BT + 16, 16]).to(tl.float32)
+        b_Ai_33 = desc.load([i_t * BT + 32, 32]).to(tl.float32)
+        b_Ai_44 = desc.load([i_t * BT + 48, 48]).to(tl.float32)
+
+    b_Ai_11 = -tl.where(m_A, b_Ai_11, 0)
+    b_Ai_22 = -tl.where(m_A, b_Ai_22, 0)
+    b_Ai_33 = -tl.where(m_A, b_Ai_33, 0)
+    b_Ai_44 = -tl.where(m_A, b_Ai_44, 0)
+
+    for i in range(2, min(16, T - i_t * BT)):
+        b_a_11 = -tl.load(A_base + (i_t * BT + i) * H * BT + o_i)
+        b_a_11 += tl.sum(b_a_11[:, None] * b_Ai_11, 0)
+        b_Ai_11 = tl.where((o_i == i)[:, None], b_a_11, b_Ai_11)
+    for i in range(16 + 2, min(32, T - i_t * BT)):
+        b_a_22 = -tl.load(A_base + (i_t * BT + i) * H * BT + o_i + 16)
+        b_a_22 += tl.sum(b_a_22[:, None] * b_Ai_22, 0)
+        b_Ai_22 = tl.where((o_i == i - 16)[:, None], b_a_22, b_Ai_22)
+    for i in range(32 + 2, min(48, T - i_t * BT)):
+        b_a_33 = -tl.load(A_base + (i_t * BT + i) * H * BT + o_i + 32)
+        b_a_33 += tl.sum(b_a_33[:, None] * b_Ai_33, 0)
+        b_Ai_33 = tl.where((o_i == i - 32)[:, None], b_a_33, b_Ai_33)
+    for i in range(48 + 2, min(64, T - i_t * BT)):
+        b_a_44 = -tl.load(A_base + (i_t * BT + i) * H * BT + o_i + 48)
+        b_a_44 += tl.sum(b_a_44[:, None] * b_Ai_44, 0)
+        b_Ai_44 = tl.where((o_i == i - 48)[:, None], b_a_44, b_Ai_44)
+    b_Ai_11 += m_I
+    b_Ai_22 += m_I
+    b_Ai_33 += m_I
+    b_Ai_44 += m_I
+
+    if not USE_TMA:
+        p_A_21 = tl.make_block_ptr(
+            A_base, (T, BT), (H * BT, 1), (i_t * BT + 16, 0), (16, 16), (1, 0)
+        )
+        p_A_31 = tl.make_block_ptr(
+            A_base, (T, BT), (H * BT, 1), (i_t * BT + 32, 0), (16, 16), (1, 0)
+        )
+        p_A_32 = tl.make_block_ptr(
+            A_base, (T, BT), (H * BT, 1), (i_t * BT + 32, 16), (16, 16), (1, 0)
+        )
+        p_A_41 = tl.make_block_ptr(
+            A_base, (T, BT), (H * BT, 1), (i_t * BT + 48, 0), (16, 16), (1, 0)
+        )
+        p_A_42 = tl.make_block_ptr(
+            A_base, (T, BT), (H * BT, 1), (i_t * BT + 48, 16), (16, 16), (1, 0)
+        )
+        p_A_43 = tl.make_block_ptr(
+            A_base, (T, BT), (H * BT, 1), (i_t * BT + 48, 32), (16, 16), (1, 0)
+        )
+        b_A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
+        b_A_31 = tl.load(p_A_31, boundary_check=(0, 1)).to(tl.float32)
+        b_A_32 = tl.load(p_A_32, boundary_check=(0, 1)).to(tl.float32)
+        b_A_41 = tl.load(p_A_41, boundary_check=(0, 1)).to(tl.float32)
+        b_A_42 = tl.load(p_A_42, boundary_check=(0, 1)).to(tl.float32)
+        b_A_43 = tl.load(p_A_43, boundary_check=(0, 1)).to(tl.float32)
+    else:
+        b_A_21 = desc.load([i_t * BT + 16, 0]).to(tl.float32)
+        b_A_31 = desc.load([i_t * BT + 32, 0]).to(tl.float32)
+        b_A_32 = desc.load([i_t * BT + 32, 16]).to(tl.float32)
+        b_A_41 = desc.load([i_t * BT + 48, 0]).to(tl.float32)
+        b_A_42 = desc.load([i_t * BT + 48, 16]).to(tl.float32)
+        b_A_43 = desc.load([i_t * BT + 48, 32]).to(tl.float32)
+
+    b_Ai_21 = -tl.dot(
+        tl.dot(b_Ai_22, b_A_21, input_precision=DOT_PRECISION),
+        b_Ai_11,
+        input_precision=DOT_PRECISION,
+    )
+    b_Ai_32 = -tl.dot(
+        tl.dot(b_Ai_33, b_A_32, input_precision=DOT_PRECISION),
+        b_Ai_22,
+        input_precision=DOT_PRECISION,
+    )
+    b_Ai_43 = -tl.dot(
+        tl.dot(b_Ai_44, b_A_43, input_precision=DOT_PRECISION),
+        b_Ai_33,
+        input_precision=DOT_PRECISION,
+    )
+    b_Ai_31 = -tl.dot(
+        b_Ai_33,
+        tl.dot(b_A_31, b_Ai_11, input_precision=DOT_PRECISION)
+        + tl.dot(b_A_32, b_Ai_21, input_precision=DOT_PRECISION),
+        input_precision=DOT_PRECISION,
+    )
+    b_Ai_42 = -tl.dot(
+        b_Ai_44,
+        tl.dot(b_A_42, b_Ai_22, input_precision=DOT_PRECISION)
+        + tl.dot(b_A_43, b_Ai_32, input_precision=DOT_PRECISION),
+        input_precision=DOT_PRECISION,
+    )
+    b_Ai_41 = -tl.dot(
+        b_Ai_44,
+        tl.dot(b_A_41, b_Ai_11, input_precision=DOT_PRECISION)
+        + tl.dot(b_A_42, b_Ai_21, input_precision=DOT_PRECISION)
+        + tl.dot(b_A_43, b_Ai_31, input_precision=DOT_PRECISION),
+        input_precision=DOT_PRECISION,
+    )
+
+    if not USE_TMA:
+        p_Ai_11 = tl.make_block_ptr(
+            A_inv_base, (T, BT), (H * BT, 1), (i_t * BT, 0), (16, 16), (1, 0)
+        )
+        p_Ai_22 = tl.make_block_ptr(
+            A_inv_base,
+            (T, BT),
+            (H * BT, 1),
+            (i_t * BT + 16, 16),
+            (16, 16),
+            (1, 0),
+        )
+        p_Ai_33 = tl.make_block_ptr(
+            A_inv_base,
+            (T, BT),
+            (H * BT, 1),
+            (i_t * BT + 32, 32),
+            (16, 16),
+            (1, 0),
+        )
+        p_Ai_44 = tl.make_block_ptr(
+            A_inv_base,
+            (T, BT),
+            (H * BT, 1),
+            (i_t * BT + 48, 48),
+            (16, 16),
+            (1, 0),
+        )
+        p_Ai_21 = tl.make_block_ptr(
+            A_inv_base,
+            (T, BT),
+            (H * BT, 1),
+            (i_t * BT + 16, 0),
+            (16, 16),
+            (1, 0),
+        )
+        p_Ai_31 = tl.make_block_ptr(
+            A_inv_base,
+            (T, BT),
+            (H * BT, 1),
+            (i_t * BT + 32, 0),
+            (16, 16),
+            (1, 0),
+        )
+        p_Ai_32 = tl.make_block_ptr(
+            A_inv_base,
+            (T, BT),
+            (H * BT, 1),
+            (i_t * BT + 32, 16),
+            (16, 16),
+            (1, 0),
+        )
+        p_Ai_41 = tl.make_block_ptr(
+            A_inv_base,
+            (T, BT),
+            (H * BT, 1),
+            (i_t * BT + 48, 0),
+            (16, 16),
+            (1, 0),
+        )
+        p_Ai_42 = tl.make_block_ptr(
+            A_inv_base,
+            (T, BT),
+            (H * BT, 1),
+            (i_t * BT + 48, 16),
+            (16, 16),
+            (1, 0),
+        )
+        p_Ai_43 = tl.make_block_ptr(
+            A_inv_base,
+            (T, BT),
+            (H * BT, 1),
+            (i_t * BT + 48, 32),
+            (16, 16),
+            (1, 0),
+        )
+        tl.store(
+            p_Ai_11,
+            b_Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_22,
+            b_Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_33,
+            b_Ai_33.to(p_Ai_33.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_44,
+            b_Ai_44.to(p_Ai_44.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_21,
+            b_Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_31,
+            b_Ai_31.to(p_Ai_31.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_32,
+            b_Ai_32.to(p_Ai_32.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_41,
+            b_Ai_41.to(p_Ai_41.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_42,
+            b_Ai_42.to(p_Ai_42.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+        tl.store(
+            p_Ai_43,
+            b_Ai_43.to(p_Ai_43.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+    else:
+        desc_o = make_tensor_descriptor(A_inv_base, [T, BT], [H * BT, 1], [16, 16])
+        desc_o.store(
+            [i_t * BT + 0, 0],
+            b_Ai_11.to(desc_o.dtype, fp_downcast_rounding="rtne"),
+        )
+        desc_o.store(
+            [i_t * BT + 16, 16],
+            b_Ai_22.to(desc_o.dtype, fp_downcast_rounding="rtne"),
+        )
+        desc_o.store(
+            [i_t * BT + 32, 32],
+            b_Ai_33.to(desc_o.dtype, fp_downcast_rounding="rtne"),
+        )
+        desc_o.store(
+            [i_t * BT + 48, 48],
+            b_Ai_44.to(desc_o.dtype, fp_downcast_rounding="rtne"),
+        )
+        desc_o.store(
+            [i_t * BT + 16, 0],
+            b_Ai_21.to(desc_o.dtype, fp_downcast_rounding="rtne"),
+        )
+        desc_o.store(
+            [i_t * BT + 32, 0],
+            b_Ai_31.to(desc_o.dtype, fp_downcast_rounding="rtne"),
+        )
+        desc_o.store(
+            [i_t * BT + 32, 16],
+            b_Ai_32.to(desc_o.dtype, fp_downcast_rounding="rtne"),
+        )
+        desc_o.store(
+            [i_t * BT + 48, 0],
+            b_Ai_41.to(desc_o.dtype, fp_downcast_rounding="rtne"),
+        )
+        desc_o.store(
+            [i_t * BT + 48, 16],
+            b_Ai_42.to(desc_o.dtype, fp_downcast_rounding="rtne"),
+        )
+        desc_o.store(
+            [i_t * BT + 48, 32],
+            b_Ai_43.to(desc_o.dtype, fp_downcast_rounding="rtne"),
+        )
+
+
+def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
+    g: torch.Tensor,
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    output_dtype: torch.dtype | None = None,
+    *,
+    use_g_in_kkt: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused kernel: cumsum(g) + KKT(L) + solve_tril(L -> inv). Returns (g_out, A_inv).
+    w_u stays a separate kernel (e.g. recompute_w_u_fwd) for HGMMA."""
+    B, T, Hg, K = k.shape
+    H = beta.shape[-1]
+    BT = chunk_size
+    output_dtype = output_dtype or k.dtype
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
+    )
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    g_out = torch.empty_like(g)
+    A = torch.empty(B, T, H, BT, device=g.device, dtype=torch.float32)
+    A_inv = torch.zeros(B, T, H, BT, device=g.device, dtype=output_dtype)
+
+    def grid(meta):
+        # Varlen kernels derive the sequence from chunk_indices. The batch id
+        # from i_bh is unused there, so H programs are sufficient for B > 1 too.
+        return (NT, H if cu_seqlens is not None else B * H)
+
+    chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril_kernel[grid](
+        g_in=g,
+        g_out=g_out,
+        k=k,
+        beta=beta,
+        A=A,
+        A_inv=A_inv,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        BT=BT,
+        IS_VARLEN=cu_seqlens is not None,
+        USE_G=use_g_in_kkt,
+        USE_TMA=is_tma_supported and BT == 64,
+        DOT_PRECISION=FLA_TRIL_PRECISION,
+    )
+    return g_out, A_inv

--- a/src/flag_attn/gated_delta_rule/index.py
+++ b/src/flag_attn/gated_delta_rule/index.py
@@ -1,0 +1,58 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+import torch
+import triton
+
+from .utils import tensor_cache
+
+
+@tensor_cache
+def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+
+@tensor_cache
+def prepare_chunk_indices(
+    cu_seqlens: torch.LongTensor, chunk_size: int
+) -> torch.LongTensor:
+    chunk_counts = triton.cdiv(prepare_lens(cu_seqlens), chunk_size)
+    chunk_offsets = torch.cat([cu_seqlens.new_tensor([0]), chunk_counts]).cumsum(-1)
+    chunk_arange = torch.arange(chunk_offsets[-1], device=cu_seqlens.device)
+    seq_ids = torch.repeat_interleave(
+        torch.arange(chunk_counts.numel(), device=cu_seqlens.device),
+        chunk_counts,
+    )
+    chunk_ids = chunk_arange - torch.repeat_interleave(chunk_offsets[:-1], chunk_counts)
+    return torch.stack([seq_ids, chunk_ids], 1).to(cu_seqlens)
+
+
+@tensor_cache
+def prepare_chunk_offsets(
+    cu_seqlens: torch.LongTensor, chunk_size: int
+) -> torch.LongTensor:
+    return torch.cat(
+        [
+            cu_seqlens.new_tensor([0]),
+            triton.cdiv(prepare_lens(cu_seqlens), chunk_size),
+        ]
+    ).cumsum(-1)
+
+
+@tensor_cache
+def prepare_token_indices(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    """Return a 2-D tensor ``[total_tokens, 2]`` with ``[seq_id, intra_seq_pos]``."""
+    lens = prepare_lens(cu_seqlens)
+    total = lens.sum().item()
+    seq_ids = torch.arange(
+        lens.numel(), device=cu_seqlens.device, dtype=torch.long
+    ).repeat_interleave(lens)
+    offsets = torch.zeros(lens.numel(), device=cu_seqlens.device, dtype=torch.long)
+    offsets[1:] = lens.cumsum(0)[:-1]
+    intra = (
+        torch.arange(total, device=cu_seqlens.device, dtype=torch.long)
+        - offsets[seq_ids]
+    )
+    return torch.stack([seq_ids, intra], 1)

--- a/src/flag_attn/gated_delta_rule/triton_ops_helper.py
+++ b/src/flag_attn/gated_delta_rule/triton_ops_helper.py
@@ -1,0 +1,65 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+
+import os
+
+import triton
+import triton.language as tl
+import triton.language.extra.libdevice as tldevice
+
+
+def get_exp():
+    """Return exp implementation (fast or accurate) based on env flag."""
+    return (
+        tldevice.fast_expf
+        if os.environ.get("FLAG_ATTN_USE_FAST_OPS", "0") == "1"
+        else tl.exp
+    )
+
+
+# Default exported exp to be imported by kernels.
+exp = get_exp()
+
+
+@triton.jit
+def log(x):
+    """Wrapper around tl.log that casts to fp32 first (matching the original FLA op.py)."""
+    return tl.log(x.to(tl.float32))
+
+
+try:
+    import inspect
+
+    _SUPPORTS_AUTOTUNE_CACHE = (
+        "cache_results" in inspect.signature(triton.autotune).parameters
+    )
+except Exception:
+    _SUPPORTS_AUTOTUNE_CACHE = False
+autotune_cache_kwargs = {"cache_results": True} if _SUPPORTS_AUTOTUNE_CACHE else {}
+
+
+if hasattr(triton.language, "_experimental_make_tensor_descriptor"):
+    # For Triton 3.3.x
+    make_tensor_descriptor = triton.language._experimental_make_tensor_descriptor
+elif hasattr(triton.language, "make_tensor_descriptor"):
+    # For Triton 3.4.x and later
+    make_tensor_descriptor = triton.language.make_tensor_descriptor
+else:
+    """
+    Fallback implementation when TMA is not supported.
+    Returns None to indicate TMA descriptors are unavailable.
+    Just make triton compiler happy.
+    """
+
+    @triton.jit
+    def make_tensor_descriptor(
+        base,
+        shape,
+        strides,
+        block_shape,
+        _builder=None,
+    ):
+        return None

--- a/src/flag_attn/gated_delta_rule/utils.py
+++ b/src/flag_attn/gated_delta_rule/utils.py
@@ -1,0 +1,227 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+
+import contextlib
+import functools
+import os
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+
+# Environment settings
+SUPPRESS_LEVEL = int(os.getenv("FLAG_ATTN_GDN_RECOMPUTE_SUPPRESS_LEVEL", "0"))
+FLA_GDN_FIX_BT = os.getenv("FLAG_ATTN_GDN_FIX_BT", "0") == "1"
+
+use_cuda_graph = os.environ.get("FLAG_ATTN_USE_CUDA_GRAPH", "0") == "1"
+
+
+def _detect_nvidia_hopper() -> bool:
+    """Return whether the active CUDA device is Hopper or newer."""
+    if not torch.cuda.is_available():
+        return False
+    try:
+        major, _ = torch.cuda.get_device_capability()
+        return major >= 9
+    except Exception:
+        return False
+
+
+is_nvidia_hopper = _detect_nvidia_hopper()
+
+is_tma_supported = is_nvidia_hopper and (
+    hasattr(triton.language, "_experimental_make_tensor_descriptor")
+    or hasattr(triton.language, "make_tensor_descriptor")
+)
+
+
+def tensor_cache(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
+    """
+    A decorator that caches the most recent results of a function with tensor inputs.
+
+    This decorator will store the output of the decorated function for the most recent set of input tensors.
+    The cache is limited to a fixed size (default is 4). When the cache is full, the oldest entry will be removed.
+
+    Args:
+        fn (Callable[..., torch.Tensor]):
+            The function to be decorated. It should take tensor inputs and return tensor outputs.
+
+    Returns:
+        Callable[..., torch.Tensor]:
+            A wrapped version of the input function with single-entry caching.
+    """
+
+    cache_entries: tuple[tuple | None, dict | None, Any] = []
+    cache_size = 8
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        nonlocal cache_entries
+        for i, entry in enumerate(cache_entries):
+            last_args, last_kwargs, last_result = entry
+            if (
+                len(args) == len(last_args)
+                and len(kwargs) == len(last_kwargs)
+                and all(a is b for a, b in zip(args, last_args))
+                and all(
+                    k in last_kwargs and v is last_kwargs[k] for k, v in kwargs.items()
+                )
+            ):
+                cache_entries = (
+                    cache_entries[:i]
+                    + cache_entries[i + 1 :]
+                    + [(args, kwargs, last_result)]
+                )
+                return last_result
+
+        result = fn(*args, **kwargs)
+
+        if len(cache_entries) >= cache_size:
+            cache_entries = cache_entries[1:]
+        cache_entries.append((args, kwargs, result))
+        return result
+
+    return wrapper
+
+
+def input_guard(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
+    """
+    A decorator to make sure all input tensors are contiguous and set the device based on input tensors.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        contiguous_args = (
+            i if not isinstance(i, torch.Tensor) else i.contiguous() for i in args
+        )
+        contiguous_kwargs = {
+            k: (v if not isinstance(v, torch.Tensor) else v.contiguous())
+            for k, v in kwargs.items()
+        }
+
+        tensor = None
+        for arg in args:
+            if isinstance(arg, torch.Tensor):
+                tensor = arg
+                break
+        if tensor is None:
+            for value in kwargs.values():
+                if isinstance(value, torch.Tensor):
+                    tensor = value
+                    break
+
+        if tensor is not None and tensor.is_cuda:
+            ctx = torch.cuda.device(tensor.device)
+        else:
+            ctx = contextlib.nullcontext()
+
+        with ctx:
+            return fn(*contiguous_args, **contiguous_kwargs)
+
+    return wrapper
+
+
+def check_shared_mem(arch: str = "none", tensor_idx: int = 0) -> bool:
+    del arch, tensor_idx
+    if not torch.cuda.is_available():
+        return False
+    try:
+        props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    except Exception:
+        return False
+
+    # property names differ across torch versions/drivers; try common ones
+    max_shared = getattr(props, "max_shared_memory_per_multiprocessor", None)
+    if max_shared is None:
+        max_shared = getattr(props, "max_shared_memory", None)
+    if max_shared is None:
+        # fallback conservative default
+        return False
+    # Use the AMPERE threshold used in the original project as heuristic
+    return max_shared >= 166_000
+
+
+# ===========================================================================
+# Bitonic sort utilities (used by NSA top-k selection kernel)
+# ===========================================================================
+
+
+@triton.jit
+def _log2(x):
+    """Compute log2 of a compile-time constant integer."""
+    return x.bit_length() - 1
+
+
+@triton.jit
+def _compare_and_swap(x, ids, flip, i: tl.constexpr, n_dims: tl.constexpr):
+    n_outer: tl.constexpr = x.numel >> n_dims
+    shape: tl.constexpr = [n_outer * 2**i, 2, 2 ** (n_dims - i - 1)]
+    y = tl.reshape(x, shape)
+    # slice left/right with 'stride' 2**(n_dims - i - 1)
+    mask = tl.arange(0, 2)[None, :, None]
+    left = tl.broadcast_to(tl.sum(y * (1 - mask), 1)[:, None, :], shape).to(y.dtype)
+    right = tl.broadcast_to(tl.sum(y * mask, 1)[:, None, :], shape).to(y.dtype)
+    left = tl.reshape(left, x.shape)
+    right = tl.reshape(right, x.shape)
+    # idx
+    y_idx = tl.reshape(ids, shape)
+    left_idx = tl.broadcast_to(tl.sum(y_idx * (1 - mask), 1)[:, None, :], shape)
+    right_idx = tl.broadcast_to(tl.sum(y_idx * mask, 1)[:, None, :], shape)
+    left_idx = tl.reshape(left_idx, x.shape).to(y_idx.dtype)
+    right_idx = tl.reshape(right_idx, x.shape).to(y_idx.dtype)
+    # actual compare-and-swap
+    idtype = tl.core.get_int_dtype(bitwidth=x.dtype.primitive_bitwidth, signed=True)
+    ileft = left.to(idtype, bitcast=True)
+    iright = right.to(idtype, bitcast=True)
+    ix = x.to(idtype, bitcast=True)
+
+    cond = (left > right) != flip
+    ret = ix ^ tl.where(cond, ileft ^ iright, tl.zeros_like(ix))
+    new_ids = ids ^ tl.where(cond, left_idx ^ right_idx, tl.zeros_like(ids))
+    return ret.to(x.dtype, bitcast=True), new_ids
+
+
+@triton.jit
+def _bitonic_merge(
+    x, ids, stage: tl.constexpr, order: tl.constexpr, n_dims: tl.constexpr
+):
+    n_outer: tl.constexpr = x.numel >> n_dims
+    tl.static_assert(stage <= n_dims)
+    # flip denotes whether to re-arrange sub-sequences of elements in ascending or
+    # descending order.
+    # if flip = 00000000... then all elements will be re-arranged ascendingly at this stage
+    # if flip = 00110011... then all the elements will be re-arranged alternatingly (with
+    # a stride of 2) at this stage
+    if order == 2:
+        shape: tl.constexpr = [n_outer * 2 ** (n_dims - 1 - stage), 2, 2**stage]
+        flip = tl.reshape(
+            tl.broadcast_to(tl.arange(0, 2)[None, :, None], shape), x.shape
+        )
+    else:
+        flip = order
+    # perform `stage` rounds of `compare-and-swap`
+    for i in tl.static_range(stage):
+        x, ids = _compare_and_swap(x, ids, flip, i + (n_dims - stage), n_dims)
+    return x, ids
+
+
+@triton.jit
+def argsort(
+    x, ids, dim: tl.constexpr = None, descending: tl.constexpr = tl.core.CONSTEXPR_0
+):
+    # handle default dimension or check that it is the most minor dim
+    _dim: tl.constexpr = len(x.shape) - 1 if dim is None else dim
+    tl.static_assert(
+        _dim == len(x.shape) - 1, "only minor dimension is currently supported"
+    )
+    # iteratively run bitonic merge-sort steps
+    n_dims: tl.constexpr = _log2(x.shape[_dim])
+
+    for i in tl.static_range(1, n_dims + 1):
+        x, ids = _bitonic_merge(x, ids, i, 2 if i < n_dims else descending, n_dims)
+    return x, ids

--- a/src/flag_attn/gated_delta_rule/wy_fast.py
+++ b/src/flag_attn/gated_delta_rule/wy_fast.py
@@ -1,0 +1,320 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+# ruff: noqa: E501
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from .compat import has_triton_tle, libentry, libtuner
+from .index import prepare_chunk_indices
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE_RECOMPUTE_W_U = True
+    except ImportError:
+        tle = None
+        HAS_TLE_RECOMPUTE_W_U = False
+else:
+    tle = None
+    HAS_TLE_RECOMPUTE_W_U = False
+
+
+def _use_tle_recompute_w_u(cu_seqlens: torch.Tensor | None) -> bool:
+    value = os.environ.get("FLAG_ATTN_CHUNK_GDR_RECOMPUTE_TLE", "1").lower()
+    return (
+        HAS_TLE_RECOMPUTE_W_U
+        and cu_seqlens is None
+        and value not in {"0", "false", "off", "no"}
+    )
+
+
+def maybe_set_tle_recompute_allocator(
+    device: torch.device, cu_seqlens: torch.Tensor | None
+) -> None:
+    if not (HAS_TLE_RECOMPUTE_W_U and cu_seqlens is None):
+        return
+
+    def alloc_fn(size: int, align: int, stream):
+        _ = align
+        _ = stream
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
+
+
+@libentry()
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@libtuner(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["H", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
+)
+@triton.jit(do_not_specialize=["T"])
+def recompute_w_u_fwd_kernel(
+    k,
+    v,
+    beta,
+    w,
+    u,
+    A,
+    g,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    p_beta = tl.make_block_ptr(
+        beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+    )
+    p_g = tl.make_block_ptr(g + (bos * H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, 0),
+        (BT, BT),
+        (1, 0),
+    )
+    b_beta = tl.load(p_beta, boundary_check=(0,))
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_g = tl.exp(tl.load(p_g, boundary_check=(0,)).to(tl.float32))
+
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(
+            v + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        p_u = tl.make_block_ptr(
+            u + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_vb = (b_v * b_beta[:, None]).to(b_v.dtype)
+        b_u = tl.dot(b_A, b_vb, allow_tf32=False)
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k = tl.make_block_ptr(
+            k + (bos * Hg + i_h // (H // Hg)) * K,
+            (T, K),
+            (Hg * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_w = tl.make_block_ptr(
+            w + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_kb = (b_k * b_beta[:, None] * b_g[:, None]).to(b_k.dtype)
+        b_w = tl.dot(b_A, b_kb)
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+
+
+if HAS_TLE_RECOMPUTE_W_U:
+
+    @libentry()
+    @libtuner(
+        configs=[
+            triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+            for num_warps in [2, 4]
+            for num_stages in [2, 3]
+        ],
+        key=["H", "K", "V", "BT", "BK", "BV", "PIPE_STAGES"],
+    )
+    @triton.jit(do_not_specialize=["T"])
+    def recompute_w_u_fwd_tle_kernel(
+        k,
+        v,
+        beta,
+        w,
+        u,
+        A,
+        g,
+        T,
+        H: tl.constexpr,
+        Hg: tl.constexpr,
+        K: tl.constexpr,
+        V: tl.constexpr,
+        BT: tl.constexpr,
+        BK: tl.constexpr,
+        BV: tl.constexpr,
+        PIPE_STAGES: tl.constexpr,
+    ):
+        i_t, i_bh = tl.program_id(0), tl.program_id(1)
+        i_b, i_h = i_bh // H, i_bh % H
+        bos = i_b * T
+
+        p_beta = tl.make_block_ptr(
+            beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+        )
+        p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+        p_A = tl.make_block_ptr(
+            A + (bos * H + i_h) * BT,
+            (T, BT),
+            (H * BT, 1),
+            (i_t * BT, 0),
+            (BT, BT),
+            (1, 0),
+        )
+        b_beta = tl.load(p_beta, boundary_check=(0,))
+        b_A = tl.load(p_A, boundary_check=(0, 1))
+        b_g = tl.exp(tl.load(p_g, boundary_check=(0,)).to(tl.float32))
+
+        for i_v in tl.range(0, tl.cdiv(V, BV), 1, num_stages=PIPE_STAGES):
+            p_v = tl.make_block_ptr(
+                v + (bos * H + i_h) * V,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT, i_v * BV),
+                (BT, BV),
+                (1, 0),
+            )
+            p_u = tl.make_block_ptr(
+                u + (bos * H + i_h) * V,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT, i_v * BV),
+                (BT, BV),
+                (1, 0),
+            )
+            b_v = tle.load(p_v, boundary_check=(0, 1), is_async=True)
+            b_vb = (b_v * b_beta[:, None]).to(b_v.dtype)
+            b_u = tl.dot(b_A, b_vb, allow_tf32=False)
+            tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+
+        for i_k in tl.range(0, tl.cdiv(K, BK), 1, num_stages=PIPE_STAGES):
+            p_k = tl.make_block_ptr(
+                k + (bos * Hg + i_h // (H // Hg)) * K,
+                (T, K),
+                (Hg * K, 1),
+                (i_t * BT, i_k * BK),
+                (BT, BK),
+                (1, 0),
+            )
+            p_w = tl.make_block_ptr(
+                w + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT, i_k * BK),
+                (BT, BK),
+                (1, 0),
+            )
+            b_k = tle.load(p_k, boundary_check=(0, 1), is_async=True)
+            b_kb = (b_k * b_beta[:, None] * b_g[:, None]).to(b_k.dtype)
+            b_w = tl.dot(b_A, b_kb)
+            tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+
+
+def recompute_w_u_fwd(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g_cumsum: torch.Tensor,
+    A: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None,
+    block_v: int | None = None,
+    pipe_stages: int = 2,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, Hg, K, V = *k.shape, v.shape[-1]
+    H = v.shape[-2]
+    BT = A.shape[-1]
+
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
+    )
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BK = 64
+    BV = block_v or 64
+    u = torch.empty_like(v)
+    w = k.new_empty(B, T, H, K)
+    if _use_tle_recompute_w_u(cu_seqlens):
+        recompute_w_u_fwd_tle_kernel[(NT, B * H)](
+            k=k,
+            v=v,
+            beta=beta,
+            w=w,
+            u=u,
+            A=A,
+            g=g_cumsum,
+            T=T,
+            H=H,
+            Hg=Hg,
+            K=K,
+            V=V,
+            BT=BT,
+            BK=BK,
+            BV=BV,
+            PIPE_STAGES=pipe_stages,
+        )
+        return w, u
+
+    # Varlen kernels get the sequence from chunk_indices; i_b is unused in the
+    # IS_VARLEN path, so H programs cover every chunk/head exactly once even
+    # when the packed storage has B > 1.
+    NH = H if cu_seqlens is not None else B * H
+    recompute_w_u_fwd_kernel[(NT, NH)](
+        k=k,
+        v=v,
+        beta=beta,
+        w=w,
+        u=u,
+        A=A,
+        g=g_cumsum,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=BK,
+        BV=BV,
+    )
+    return w, u

--- a/src/flag_attn/testing/__init__.py
+++ b/src/flag_attn/testing/__init__.py
@@ -1,4 +1,4 @@
 from flag_attn.testing.flash import attention as flash_attention # noqa: F401
 from flag_attn.testing.piecewise import attention as piecewise_attention # noqa: F401
 from flag_attn.testing.paged import attention as paged_attention # noqa: F401
-from flag_attn.testing.dropout import recompute_mask
+from flag_attn.testing.dropout import recompute_mask # noqa: F401

--- a/src/flag_attn/testing/paged.py
+++ b/src/flag_attn/testing/paged.py
@@ -1,4 +1,3 @@
-import math
 import torch
 
 

--- a/tests/flag_attn/test_gated_delta_rule.py
+++ b/tests/flag_attn/test_gated_delta_rule.py
@@ -142,7 +142,7 @@ def test_chunk_gated_delta_rule_fwd_full_tle_matches_native(dtype, shape):
 @torch.inference_mode()
 def test_chunk_gated_delta_rule_public_api_matches_native(dtype):
     torch.manual_seed(42)
-    args = _make_inputs(4, 2048, 16, 128, 128, dtype, use_initial_state=False)
+    args = _make_inputs(1, 256, 2, 128, 128, dtype, use_initial_state=False)
     baseline = _call_fwd(args, full_tle=False, recompute_tle=False)
     q, k, v, g, beta, scale, _, _, _ = args
 

--- a/tests/flag_attn/test_gated_delta_rule.py
+++ b/tests/flag_attn/test_gated_delta_rule.py
@@ -11,6 +11,7 @@ from flag_attn.gated_delta_rule.compat import has_triton_tle
 ASSERT_RATIO = 0.01
 RECOMPUTE_TLE_ENV = "FLAG_ATTN_CHUNK_GDR_RECOMPUTE_TLE"
 FULL_TLE_ENV = "FLAG_ATTN_CHUNK_GATED_DELTA_RULE_TLE"
+TWO_KERNEL_TLE_ENV = "FLAG_ATTN_CHUNK_GDR_TWO_KERNEL_TLE"
 
 GDN_RECOMPUTE_TEST_SHAPES = [
     (2, 16384, 16, 128, 128),
@@ -26,17 +27,27 @@ GDN_FUSED_FWD_TEST_SHAPES = [
     (4, 4096, 64, 128, 128),
 ]
 
+GDN_TWO_KERNEL_TEST_SHAPES = [
+    (4, 2048, 16, 128, 128),
+    (4, 4096, 64, 128, 128),
+    (8, 2048, 32, 256, 256),
+]
+
 
 def _cuda_tle_available() -> bool:
     return torch.cuda.is_available() and has_triton_tle(3, 6, 0)
 
 
 @contextmanager
-def _set_gdn_tle(*, full_tle: bool, recompute_tle: bool):
+def _set_gdn_tle(
+    *, full_tle: bool, recompute_tle: bool, two_kernel_tle: bool
+):
     old_full = os.environ.get(FULL_TLE_ENV)
     old_recompute = os.environ.get(RECOMPUTE_TLE_ENV)
+    old_two_kernel = os.environ.get(TWO_KERNEL_TLE_ENV)
     os.environ[FULL_TLE_ENV] = "1" if full_tle else "0"
     os.environ[RECOMPUTE_TLE_ENV] = "1" if recompute_tle else "0"
+    os.environ[TWO_KERNEL_TLE_ENV] = "1" if two_kernel_tle else "0"
     try:
         yield
     finally:
@@ -48,6 +59,10 @@ def _set_gdn_tle(*, full_tle: bool, recompute_tle: bool):
             os.environ.pop(RECOMPUTE_TLE_ENV, None)
         else:
             os.environ[RECOMPUTE_TLE_ENV] = old_recompute
+        if old_two_kernel is None:
+            os.environ.pop(TWO_KERNEL_TLE_ENV, None)
+        else:
+            os.environ[TWO_KERNEL_TLE_ENV] = old_two_kernel
 
 
 def _make_inputs(
@@ -74,8 +89,18 @@ def _make_inputs(
     return q, k, v, g, beta, K**-0.5, initial_state, True, None
 
 
-def _call_fwd(args, *, full_tle: bool, recompute_tle: bool):
-    with _set_gdn_tle(full_tle=full_tle, recompute_tle=recompute_tle):
+def _call_fwd(
+    args,
+    *,
+    full_tle: bool,
+    recompute_tle: bool,
+    two_kernel_tle: bool = False,
+):
+    with _set_gdn_tle(
+        full_tle=full_tle,
+        recompute_tle=recompute_tle,
+        two_kernel_tle=two_kernel_tle,
+    ):
         return chunk_gated_delta_rule_fwd(*args)
 
 
@@ -146,7 +171,11 @@ def test_chunk_gated_delta_rule_public_api_matches_native(dtype):
     baseline = _call_fwd(args, full_tle=False, recompute_tle=False)
     q, k, v, g, beta, scale, _, _, _ = args
 
-    with _set_gdn_tle(full_tle=True, recompute_tle=True):
+    with _set_gdn_tle(
+        full_tle=True,
+        recompute_tle=True,
+        two_kernel_tle=False,
+    ):
         o, final_state = chunk_gated_delta_rule(
             q,
             k,
@@ -160,3 +189,27 @@ def test_chunk_gated_delta_rule_public_api_matches_native(dtype):
 
     _assert_close("o", o, baseline[1])
     _assert_close("final_state", final_state, baseline[3])
+
+
+@pytest.mark.skipif(
+    not _cuda_tle_available(), reason="GDN two-kernel tests require CUDA/TLE"
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("shape", GDN_TWO_KERNEL_TEST_SHAPES)
+@torch.inference_mode()
+def test_chunk_gated_delta_rule_fwd_two_kernel_matches_native(dtype, shape):
+    torch.manual_seed(42)
+    args = _make_inputs(*shape, dtype=dtype, use_initial_state=False)
+
+    baseline = _call_fwd(args, full_tle=False, recompute_tle=False)
+    actual = _call_fwd(
+        args,
+        full_tle=False,
+        recompute_tle=False,
+        two_kernel_tle=True,
+    )
+
+    _assert_close("g", actual[0], baseline[0])
+    _assert_close("o", actual[1], baseline[1])
+    _assert_close("A", actual[2], baseline[2])
+    _assert_close("final_state", actual[3], baseline[3])

--- a/tests/flag_attn/test_gated_delta_rule.py
+++ b/tests/flag_attn/test_gated_delta_rule.py
@@ -213,3 +213,34 @@ def test_chunk_gated_delta_rule_fwd_two_kernel_matches_native(dtype, shape):
     _assert_close("o", actual[1], baseline[1])
     _assert_close("A", actual[2], baseline[2])
     _assert_close("final_state", actual[3], baseline[3])
+
+
+@pytest.mark.skipif(
+    not _cuda_tle_available(), reason="GDN public two-kernel test requires CUDA/TLE"
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@torch.inference_mode()
+def test_chunk_gated_delta_rule_public_api_uses_two_kernel(dtype):
+    torch.manual_seed(42)
+    args = _make_inputs(4, 2048, 16, 128, 128, dtype, use_initial_state=False)
+    baseline = _call_fwd(args, full_tle=False, recompute_tle=False)
+    q, k, v, g, beta, scale, _, _, _ = args
+
+    with _set_gdn_tle(
+        full_tle=False,
+        recompute_tle=False,
+        two_kernel_tle=True,
+    ):
+        o, final_state = chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            beta,
+            g,
+            head_first=False,
+            scale=scale,
+            output_final_state=True,
+        )
+
+    _assert_close("o", o, baseline[1])
+    _assert_close("final_state", final_state, baseline[3])

--- a/tests/flag_attn/test_gated_delta_rule.py
+++ b/tests/flag_attn/test_gated_delta_rule.py
@@ -1,0 +1,162 @@
+import os
+from contextlib import contextmanager
+
+import pytest
+import torch
+
+from flag_attn import chunk_gated_delta_rule
+from flag_attn.gated_delta_rule import chunk_gated_delta_rule_fwd
+from flag_attn.gated_delta_rule.compat import has_triton_tle
+
+ASSERT_RATIO = 0.01
+RECOMPUTE_TLE_ENV = "FLAG_ATTN_CHUNK_GDR_RECOMPUTE_TLE"
+FULL_TLE_ENV = "FLAG_ATTN_CHUNK_GATED_DELTA_RULE_TLE"
+
+GDN_RECOMPUTE_TEST_SHAPES = [
+    (2, 16384, 16, 128, 128),
+    (4, 2048, 16, 128, 128),
+    (4, 4096, 64, 128, 128),
+    (8, 1024, 8, 64, 64),
+    (8, 2048, 32, 256, 256),
+]
+
+GDN_FUSED_FWD_TEST_SHAPES = [
+    (2, 16384, 16, 128, 128),
+    (4, 2048, 16, 128, 128),
+    (4, 4096, 64, 128, 128),
+]
+
+
+def _cuda_tle_available() -> bool:
+    return torch.cuda.is_available() and has_triton_tle(3, 6, 0)
+
+
+@contextmanager
+def _set_gdn_tle(*, full_tle: bool, recompute_tle: bool):
+    old_full = os.environ.get(FULL_TLE_ENV)
+    old_recompute = os.environ.get(RECOMPUTE_TLE_ENV)
+    os.environ[FULL_TLE_ENV] = "1" if full_tle else "0"
+    os.environ[RECOMPUTE_TLE_ENV] = "1" if recompute_tle else "0"
+    try:
+        yield
+    finally:
+        if old_full is None:
+            os.environ.pop(FULL_TLE_ENV, None)
+        else:
+            os.environ[FULL_TLE_ENV] = old_full
+        if old_recompute is None:
+            os.environ.pop(RECOMPUTE_TLE_ENV, None)
+        else:
+            os.environ[RECOMPUTE_TLE_ENV] = old_recompute
+
+
+def _make_inputs(
+    B: int,
+    T: int,
+    H: int,
+    K: int,
+    V: int,
+    dtype: torch.dtype,
+    *,
+    use_initial_state: bool,
+):
+    device = torch.device("cuda")
+    q = torch.randn(B, T, H, K, device=device, dtype=dtype) / (K**0.5)
+    k = torch.randn(B, T, H, K, device=device, dtype=dtype) / (K**0.5)
+    v = torch.randn(B, T, H, V, device=device, dtype=dtype)
+    g = (-torch.rand(B, T, H, device=device, dtype=torch.float32) * 0.1).to(dtype)
+    beta = torch.rand(B, T, H, device=device, dtype=dtype).sigmoid()
+    initial_state = (
+        torch.zeros(B, H, K, V, device=device, dtype=dtype)
+        if use_initial_state
+        else None
+    )
+    return q, k, v, g, beta, K**-0.5, initial_state, True, None
+
+
+def _call_fwd(args, *, full_tle: bool, recompute_tle: bool):
+    with _set_gdn_tle(full_tle=full_tle, recompute_tle=recompute_tle):
+        return chunk_gated_delta_rule_fwd(*args)
+
+
+def _err_ratio(expected: torch.Tensor, actual: torch.Tensor) -> float:
+    err = (expected.float() - actual.float()).flatten().square().mean().sqrt().item()
+    base = expected.float().flatten().square().mean().sqrt().item()
+    return err / (base + 1e-8)
+
+
+def _assert_close(name: str, actual: torch.Tensor, expected: torch.Tensor) -> None:
+    actual = actual.float()
+    expected = expected.float()
+    abs_err = (actual - expected).abs().max().item()
+    if abs_err <= 1e-6:
+        return
+    assert not torch.isnan(actual).any(), f"{name}: NaN detected in actual"
+    assert not torch.isnan(expected).any(), f"{name}: NaN detected in baseline"
+    ratio = _err_ratio(expected, actual)
+    assert ratio < ASSERT_RATIO, (
+        f"{name} diff: abs={abs_err:.6f} ratio={ratio:.6f} " f"limit={ASSERT_RATIO}"
+    )
+
+
+@pytest.mark.skipif(
+    not _cuda_tle_available(), reason="GDN recompute TLE tests require CUDA/TLE"
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("shape", GDN_RECOMPUTE_TEST_SHAPES)
+@torch.inference_mode()
+def test_chunk_gated_delta_rule_fwd_recompute_tle_matches_native(dtype, shape):
+    torch.manual_seed(42)
+    args = _make_inputs(*shape, dtype=dtype, use_initial_state=True)
+
+    baseline = _call_fwd(args, full_tle=False, recompute_tle=False)
+    actual = _call_fwd(args, full_tle=False, recompute_tle=True)
+
+    _assert_close("g", actual[0], baseline[0])
+    _assert_close("o", actual[1], baseline[1])
+    _assert_close("A", actual[2], baseline[2])
+    _assert_close("final_state", actual[3], baseline[3])
+
+
+@pytest.mark.skipif(
+    not _cuda_tle_available(), reason="GDN fused TLE tests require CUDA/TLE"
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("shape", GDN_FUSED_FWD_TEST_SHAPES)
+@torch.inference_mode()
+def test_chunk_gated_delta_rule_fwd_full_tle_matches_native(dtype, shape):
+    torch.manual_seed(42)
+    args = _make_inputs(*shape, dtype=dtype, use_initial_state=False)
+
+    baseline = _call_fwd(args, full_tle=False, recompute_tle=False)
+    actual = _call_fwd(args, full_tle=True, recompute_tle=True)
+
+    _assert_close("g", actual[0], baseline[0])
+    _assert_close("o", actual[1], baseline[1])
+    _assert_close("A", actual[2], baseline[2])
+    _assert_close("final_state", actual[3], baseline[3])
+
+
+@pytest.mark.skipif(not _cuda_tle_available(), reason="GDN public API test requires CUDA/TLE")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@torch.inference_mode()
+def test_chunk_gated_delta_rule_public_api_matches_native(dtype):
+    torch.manual_seed(42)
+    args = _make_inputs(4, 2048, 16, 128, 128, dtype, use_initial_state=False)
+    baseline = _call_fwd(args, full_tle=False, recompute_tle=False)
+    q, k, v, g, beta, scale, _, _, _ = args
+
+    with _set_gdn_tle(full_tle=True, recompute_tle=True):
+        o, final_state = chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            beta,
+            g,
+            head_first=False,
+            scale=scale,
+            output_final_state=True,
+        )
+
+    _assert_close("o", o, baseline[1])
+    _assert_close("final_state", final_state, baseline[3])


### PR DESCRIPTION
## Summary

Add a self-contained GDN forward operator to FlagAttention with a guarded two-kernel TLE fast path.

The optimized path uses:

1. fused chunk-local gate cumsum, KKT construction, and triangular solve;
2. fused WY recomputation, recurrent state propagation, output generation, and final-state writeback.

This removes global `w/u/h/v_new` materialization and reduces the forward pipeline to two main kernels for validated shapes. Unsupported inputs continue to use the native chunked implementation.

## Main changes

- Add the public `flag_attn.chunk_gated_delta_rule` API.
- Add the raw `chunk_gated_delta_rule_fwd` entry for validation and benchmarking.
- Add the two-kernel TLE fused-forward path.
- Preserve native, recompute-only, and existing fused fallbacks.
- Route the public API through the two-kernel path when its guard passes.
- Add correctness tests for `g`, `o`, `A`, and `final_state`.
- Benchmark native and two-kernel paths with all other TLE paths disabled.

## Two-kernel fast-path conditions

- CUDA execution with Triton/TLE 3.6+
- fp16 or bf16 inputs
- fixed-length input without `cu_seqlens`
- `initial_state is None`
- `output_final_state is True`
- `K` in `{64, 128, 256}`
- sequence length divisible by 64
- `B * H >= 64`

Low-parallelism and unsupported shapes use the native fallback.

## Correctness

```text
26 passed in 106.72s
```

The tests cover:

- two-kernel raw forward and public API paths;
- fp16 and bf16;
- D64, D128, and D256 fallback coverage;
- native, recompute-only, and fused paths;
- `g`, `o`, `A`, and `final_state` comparisons.

## H100 benchmark

Baseline:

```text
two-kernel TLE off
full TLE off
recompute TLE off
```

Optimized:

```text
two-kernel TLE on
full TLE off
recompute TLE off
```

### fp16

```text
B2_T16384_H16_D128: 1.578682 ms -> 1.580734 ms, 0.999x (guarded fallback)
B4_T2048_H16_D128:  0.421709 ms -> 0.293298 ms, 1.438x
B4_T4096_H64_D128:  2.601665 ms -> 1.879279 ms, 1.384x
```

### bf16

```text
B2_T16384_H16_D128: 1.589414 ms -> 1.588430 ms, 1.001x (guarded fallback)
B4_T2048_H16_D128:  0.425213 ms -> 0.288695 ms, 1.473x
B4_T4096_H64_D128:  2.617796 ms -> 1.886672 ms, 1.388x
```

The `B2_T16384_H16_D128` shape has `B * H = 32`; it stays on the native path because the persistent recurrence kernel does not have enough CTA-level parallelism for that workload.
