### PR TITLE
[CICD] Add openEuler 24.03 RPM build support

### DIFF
--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -16,6 +16,20 @@ on:
 jobs:
   build-rpm:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Original Fedora target — artifact name unchanged so
+          # downstream collectors keep working.
+          - target: fedora43
+            base_image: fedora
+            base_image_version: "43"
+            artifact: flag-attention-amd64-rpm-packages
+          - target: openeuler2403
+            base_image: openeuler/openeuler
+            base_image_version: 24.03-lts
+            artifact: flag-attention-amd64-oe2403-rpm-packages
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -25,12 +39,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build .rpm
+      - name: Build .rpm (${{ matrix.target }})
         run: bash packaging/rpm/build-flag-attention-rpm.sh
+        env:
+          BASE_IMAGE: ${{ matrix.base_image }}
+          BASE_IMAGE_VERSION: ${{ matrix.base_image_version }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: flag-attention-amd64-rpm-packages
+          name: ${{ matrix.artifact }}
           path: rpm-packages/*.rpm
           retention-days: 7

--- a/packaging/rpm/build-flag-attention-rpm.sh
+++ b/packaging/rpm/build-flag-attention-rpm.sh
@@ -2,12 +2,22 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
-BASE_IMAGE_VERSION="${1:-43}"
-IMAGE_TAG="flag-attention-rpm:f${BASE_IMAGE_VERSION}"
-OUTPUT_DIR="${PROJECT_DIR}/rpm-packages"
+# Defaults preserve the original single-arg Fedora flow:
+#   ./build-flag-attention-rpm.sh [fedora-version]
+# Other distros via env, e.g. openEuler 24.03:
+#   BASE_IMAGE=openeuler/openeuler BASE_IMAGE_VERSION=24.03-lts ./build-flag-attention-rpm.sh
+BASE_IMAGE="${BASE_IMAGE:-fedora}"
+BASE_IMAGE_VERSION="${BASE_IMAGE_VERSION:-${1:-43}}"
+if [ "${BASE_IMAGE}" = "fedora" ]; then
+    IMAGE_TAG="flag-attention-rpm:f${BASE_IMAGE_VERSION}"
+else
+    IMAGE_TAG="flag-attention-rpm:$(echo "${BASE_IMAGE}-${BASE_IMAGE_VERSION}" | tr '/' '-')"
+fi
+OUTPUT_DIR="${OUTPUT_DIR:-${PROJECT_DIR}/rpm-packages}"
 
 docker build --network=host \
     -f "${SCRIPT_DIR}/dockerfiles/Dockerfile.rpm" \
+    --build-arg BASE_IMAGE="$BASE_IMAGE" \
     --build-arg BASE_IMAGE_VERSION="$BASE_IMAGE_VERSION" \
     -t "$IMAGE_TAG" "$PROJECT_DIR"
 

--- a/packaging/rpm/dockerfiles/Dockerfile.rpm
+++ b/packaging/rpm/dockerfiles/Dockerfile.rpm
@@ -4,9 +4,34 @@ ARG BASE_IMAGE_VERSION=43
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
 RUN dnf install -y \
-    rpm-build rpmdevtools pyproject-rpm-macros \
+    rpm-build rpmdevtools \
     python3-devel python3-setuptools python3-wheel python3-pip python3-setuptools_scm \
     && dnf clean all
+
+# pyproject-rpm-macros exists on Fedora/EL9+ but not openEuler 24.03;
+# the spec falls back to a pip-based build when it is absent.
+RUN dnf install -y pyproject-rpm-macros && dnf clean all \
+    || echo "pyproject-rpm-macros unavailable; spec uses pip fallback"
+
+# pyproject.toml declares setuptools-scm>=8.0; openEuler 24.03 ships
+# 7.1.0. Upgrade only when the distro version is too old (no-op on
+# Fedora). --prefix /usr overwrites the distro module in place: python
+# drops /usr/local from sys.path inside rpmbuild (RPM_BUILD_ROOT
+# detection), so a default pip install would be invisible to %build.
+RUN python3 -c "import importlib.metadata as m, sys; \
+        sys.exit(0 if int(m.version('setuptools-scm').split('.')[0]) >= 8 else 1)" \
+    || { python3 -m pip install --no-cache-dir --prefix /usr "setuptools-scm>=8.0" \
+         && rm -rf /usr/lib/python3.11/site-packages/setuptools_scm-7.*.dist-info; }
+
+# openEuler images define %dist as empty (official .oe* tags are
+# injected by EulerMaker); reconstruct it so local/CI builds get
+# distro-tagged Release fields like official packages.
+RUN if [ -z "$(rpm --eval '%{?dist}')" ]; then \
+        . /etc/os-release && \
+        case "${ID}" in \
+            openEuler) echo "%dist .oe$(echo "${VERSION_ID}" | tr -d '.')" >> /root/.rpmmacros ;; \
+        esac; \
+    fi
 
 RUN rpmdev-setuptree
 

--- a/packaging/rpm/dockerfiles/Dockerfile.rpm
+++ b/packaging/rpm/dockerfiles/Dockerfile.rpm
@@ -3,15 +3,16 @@ ARG BASE_IMAGE_VERSION=43
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION}
 
+# pyproject-rpm-macros exists on Fedora/EL9+ but not openEuler 24.03;
+# the spec falls back to a pip-based build when it is absent. Same RUN
+# as the toolchain install: a separate layer would re-download all repo
+# metadata (dnf clean all), which on slow mirrors costs tens of minutes.
 RUN dnf install -y \
     rpm-build rpmdevtools \
     python3-devel python3-setuptools python3-wheel python3-pip python3-setuptools_scm \
+    && (dnf install -y pyproject-rpm-macros \
+        || echo "pyproject-rpm-macros unavailable; spec uses pip fallback") \
     && dnf clean all
-
-# pyproject-rpm-macros exists on Fedora/EL9+ but not openEuler 24.03;
-# the spec falls back to a pip-based build when it is absent.
-RUN dnf install -y pyproject-rpm-macros && dnf clean all \
-    || echo "pyproject-rpm-macros unavailable; spec uses pip fallback"
 
 # pyproject.toml declares setuptools-scm>=8.0; openEuler 24.03 ships
 # 7.1.0. Upgrade only when the distro version is too old (no-op on

--- a/packaging/rpm/specs/flag-attention.spec
+++ b/packaging/rpm/specs/flag-attention.spec
@@ -1,5 +1,17 @@
 %global debug_package %{nil}
 
+# Distros that ship pyproject-rpm-macros (Fedora, EL9+) build via the
+# %%pyproject_* macro family — that path is unchanged. Distros without
+# it (openEuler 24.03, EL8-family) fall back to a plain pip
+# wheel/install build. Capability-detected at parse time, so the build
+# container must have its python toolchain installed before rpmbuild
+# runs (both Dockerfile.rpm paths do).
+%if %{defined pyproject_wheel}
+%global has_pyproject_macros 1
+%else
+%global has_pyproject_macros 0
+%endif
+
 # Filter the auto-generated Requires for: triton.
 # Reason: distro triton has no current version; users install via pip.
 # See packaging/INSTALL.md (or future flagos-packaging install docs) for the
@@ -10,8 +22,10 @@ Name:           python3-flag-attention
 #   1. this Version: line
 #   2. packaging/debian/changelog (latest entry)
 #   3. packaging/debian/rules SETUPTOOLS_SCM_PRETEND_VERSION
-# (spec %build / %install pass SETUPTOOLS_SCM_PRETEND_VERSION=%{version} so
-#  they self-update with the Version: line above.)
+# (spec %%build / %%install pass SETUPTOOLS_SCM_PRETEND_VERSION=%%{version} so
+#  they self-update with the Version: line above. %% escaped: openEuler's
+#  rpm expands macros even in comments and a bare %%install here would
+#  terminate the preamble.)
 Version:        0.3.0
 Release:        1%{?dist}
 Summary:        FlagAttention — memory-efficient attention operators (Triton)
@@ -24,8 +38,10 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools >= 60
 BuildRequires:  python3-wheel
 BuildRequires:  python3-pip
-BuildRequires:  pyproject-rpm-macros
 BuildRequires:  python3-setuptools_scm
+%if %{has_pyproject_macros}
+BuildRequires:  pyproject-rpm-macros
+%endif
 
 %description
 Collection of memory-efficient attention operators implemented in the Triton language, for large language model training and inference.
@@ -35,12 +51,21 @@ Collection of memory-efficient attention operators implemented in the Triton lan
 
 %build
 export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
+%if %{has_pyproject_macros}
 %pyproject_wheel
+%else
+%{__python3} -m pip wheel --no-deps --no-build-isolation --wheel-dir dist .
+%endif
 
 %install
 export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
+%if %{has_pyproject_macros}
 %pyproject_install
 %pyproject_save_files flag_attn
+%else
+%{__python3} -m pip install --no-deps --no-index --no-warn-script-location \
+    --root %{buildroot} dist/*.whl
+%endif
 
 %check
 # Smoke find_spec test (no actual import) — verifies the built module
@@ -51,9 +76,20 @@ PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPATH=%{buildroot}%{python3_sitelib} \
     python3 -c "import importlib.util; s = importlib.util.find_spec('flag_attn'); assert s and s.origin, 'flag_attn not findable'; print('OK: flag_attn at', s.origin)"
 
+%if %{has_pyproject_macros}
 %files -f %{pyproject_files}
 %license LICENSE
+%else
+%files
+%license LICENSE
+%{python3_sitelib}/flag_attn/
+%{python3_sitelib}/flag_attn-%{version}.dist-info/
+%endif
 
 %changelog
+* Mon Jul 13 2026 FlagOS Contributors <contact@flagos.io> - 0.3.0-1
+- Add pip-based fallback for distros without pyproject-rpm-macros
+  (openEuler 24.03); Fedora build path unchanged.
+
 * Wed May 13 2026 FlagOS Contributors <contact@flagos.io> - 0.3.0-1
 - Initial RPM packaging.

--- a/packaging/rpm/specs/flag-attention.spec
+++ b/packaging/rpm/specs/flag-attention.spec
@@ -64,7 +64,7 @@ export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
 %pyproject_save_files flag_attn
 %else
 %{__python3} -m pip install --no-deps --no-index --no-warn-script-location \
-    --root %{buildroot} dist/*.whl
+    --root %{buildroot} --prefix /usr dist/*.whl
 %endif
 
 %check


### PR DESCRIPTION
## Summary

Extends the RPM packaging so the same spec builds on **openEuler
24.03 LTS** in addition to Fedora 43. Same template as
flagos-ai/FlagSparse#29 (all three checks green there): openEuler
ships Python 3.11 and no `pyproject-rpm-macros`, so the Fedora-built
`.fc43` noarch RPM (`python(abi) = 3.14`) cannot install there.

## What changed (packaging + CI only, no source changes)

- `packaging/rpm/specs/flag-attention.spec` — parse-time capability
  check: with `%pyproject_wheel` defined (Fedora/EL9+) the existing
  macro path is used **unchanged**; otherwise a pip-based fallback
  with an explicit `%files` list. Also escapes macros in a preamble
  comment: openEuler's rpm expands macros inside comments, and the
  bare `%install` in the version-sync NOTE terminated the preamble
  ("Version field must be present" errors).
- `packaging/rpm/dockerfiles/Dockerfile.rpm` — installs
  `pyproject-rpm-macros` opportunistically; reconstructs the empty
  `%dist` on openEuler (`.oe2403`); upgrades `setuptools-scm` via
  `pip --prefix /usr` when the distro version is <8 (pyproject
  declares `setuptools-scm>=8.0`, openEuler ships 7.1.0; `--prefix
  /usr` because python drops `/usr/local` from `sys.path` inside
  rpmbuild).
- `packaging/rpm/build-flag-attention-rpm.sh` — `BASE_IMAGE` /
  `BASE_IMAGE_VERSION` / `OUTPUT_DIR` env overrides; the original
  single-arg Fedora flow is preserved.
- `.github/workflows/build-rpm.yml` — build matrix
  `fedora43` + `openeuler2403` (`fail-fast: false`); Fedora artifact
  name unchanged (`flag-attention-amd64-rpm-packages`).

## Tested

Both targets built locally via the modified script:

| Target | Artifact | python(abi) | Result |
|--------|----------|-------------|--------|
| fedora43 (regression) | `python3-flag-attention-0.3.0-1.fc43.noarch.rpm` | 3.14 | build unchanged vs main |
| openeuler2403 | `python3-flag-attention-0.3.0-1.oe2403.noarch.rpm` | 3.11 | installs + `find_spec('flag_attn')` passes on `openeuler/openeuler:24.03-lts` |

## Limitations

- openEuler artifact not yet consumed downstream (flagos-packaging
  routing is a follow-up).
- EL8-family would take the same fallback path but is not in the
  matrix yet.
